### PR TITLE
Edit tasks

### DIFF
--- a/components/GoalScreen.tsx
+++ b/components/GoalScreen.tsx
@@ -25,6 +25,7 @@ export default function GoalScreen({ navigation, route }: GoalProps) {
   const goal = useStore((s) => s.goals.find((g) => g.id === goalId)!);
   const selectedDate = useStore((s) => s.selectedDate);
   const addTask = useStore((s) => s.addTask);
+  const updateTask = useStore((s) => s.updateTask);
   const updateGoal = useStore((s) => s.updateGoal);
   const deleteTask = useStore((s) => s.deleteTask);
   const toggleTask = useStore((s) => s.toggleTaskCompletion);
@@ -34,6 +35,7 @@ export default function GoalScreen({ navigation, route }: GoalProps) {
   const [frequency, setFrequency] = React.useState<Frequency>("daily");
   const [customFrequency, setCustomFrequency] = React.useState<CustomFrequency>({ type: "weekly", target: 3 });
   const [isEditing, setIsEditing] = React.useState(false);
+  const [editingTaskId, setEditingTaskId] = React.useState<string | null>(null);
   const [isEditingGoalTitle, setIsEditingGoalTitle] = React.useState(false);
   const [goalTitleDraft, setGoalTitleDraft] = React.useState(goal.title);
 
@@ -77,6 +79,59 @@ export default function GoalScreen({ navigation, route }: GoalProps) {
 
     void haptics.toggle();
     setCustomFrequency((prev) => ({ ...prev, target: nextTarget }));
+  };
+
+  const resetTaskEditor = () => {
+    setTaskTitle("");
+    setFrequency("daily");
+    setCustomFrequency({ type: "weekly", target: 3 });
+    setEditingTaskId(null);
+    setIsEditing(false);
+  };
+
+  const startEditingTask = (taskId: string) => {
+    const task = goal.tasks.find((item) => item.id === taskId);
+
+    if (!task) {
+      void haptics.error();
+      return;
+    }
+
+    setTaskTitle(task.title);
+    setFrequency(task.frequency);
+    setCustomFrequency(task.customFrequency ?? { type: "weekly", target: 3 });
+    setEditingTaskId(task.id);
+    setIsEditing(true);
+    void haptics.tap();
+  };
+
+  const submitTaskEditor = () => {
+    const trimmedTitle = taskTitle.trim();
+
+    if (!trimmedTitle) {
+      void haptics.error();
+      return;
+    }
+
+    const normalizedCustomFrequency = frequency === "custom"
+      ? {
+          ...customFrequency,
+          target: normalizeCustomTarget(customFrequency.target, customFrequency.type),
+        }
+      : undefined;
+
+    if (editingTaskId) {
+      updateTask(goalId, editingTaskId, {
+        title: trimmedTitle,
+        frequency,
+        customFrequency: normalizedCustomFrequency,
+      });
+    } else {
+      addTask(goalId, trimmedTitle, frequency, normalizedCustomFrequency);
+    }
+
+    void haptics.success();
+    resetTaskEditor();
   };
 
   const confirmDeleteTask = (taskId: string, taskTitle: string) => {
@@ -374,19 +429,34 @@ export default function GoalScreen({ navigation, route }: GoalProps) {
                       );
                     })()}
                   </View>
-                  <Pressable
-                    onPress={() => confirmDeleteTask(item.id, item.title)}
-                    hitSlop={8}
-                    style={{
-                      alignSelf: "center",
-                      borderRadius: 9999,
-                      paddingHorizontal: 4,
-                      paddingVertical: 4,
-                      opacity: 0.35
-                    }}
-                  >
-                    <Ionicons name="trash-outline" size={16} color={theme.textSecondary} />
-                  </Pressable>
+                  <View style={{ alignSelf: "center", gap: 6 }}>
+                    <Pressable
+                      onPress={() => startEditingTask(item.id)}
+                      hitSlop={8}
+                      style={{
+                        alignSelf: "center",
+                        borderRadius: 9999,
+                        paddingHorizontal: 4,
+                        paddingVertical: 4,
+                        opacity: 0.55
+                      }}
+                    >
+                      <Ionicons name="create-outline" size={16} color={theme.textSecondary} />
+                    </Pressable>
+                    <Pressable
+                      onPress={() => confirmDeleteTask(item.id, item.title)}
+                      hitSlop={8}
+                      style={{
+                        alignSelf: "center",
+                        borderRadius: 9999,
+                        paddingHorizontal: 4,
+                        paddingVertical: 4,
+                        opacity: 0.35
+                      }}
+                    >
+                      <Ionicons name="trash-outline" size={16} color={theme.textSecondary} />
+                    </Pressable>
+                  </View>
                 </View>
               </Pressable>
               {index < pendingTasks.length - 1 && <View style={{ height: 8 }} />}
@@ -478,19 +548,34 @@ export default function GoalScreen({ navigation, route }: GoalProps) {
                         );
                       })()}
                     </View>
-                    <Pressable
-                      onPress={() => confirmDeleteTask(item.id, item.title)}
-                      hitSlop={8}
-                      style={{
-                        alignSelf: "center",
-                        borderRadius: 9999,
-                        paddingHorizontal: 4,
-                        paddingVertical: 4,
-                        opacity: 0.35
-                      }}
-                    >
-                      <Ionicons name="trash-outline" size={16} color={theme.textSecondary} />
-                    </Pressable>
+                    <View style={{ alignSelf: "center", gap: 6 }}>
+                      <Pressable
+                        onPress={() => startEditingTask(item.id)}
+                        hitSlop={8}
+                        style={{
+                          alignSelf: "center",
+                          borderRadius: 9999,
+                          paddingHorizontal: 4,
+                          paddingVertical: 4,
+                          opacity: 0.55
+                        }}
+                      >
+                        <Ionicons name="create-outline" size={16} color={theme.textSecondary} />
+                      </Pressable>
+                      <Pressable
+                        onPress={() => confirmDeleteTask(item.id, item.title)}
+                        hitSlop={8}
+                        style={{
+                          alignSelf: "center",
+                          borderRadius: 9999,
+                          paddingHorizontal: 4,
+                          paddingVertical: 4,
+                          opacity: 0.35
+                        }}
+                      >
+                        <Ionicons name="trash-outline" size={16} color={theme.textSecondary} />
+                      </Pressable>
+                    </View>
                   </View>
                 </Pressable>
                 {index < completedTasks.length - 1 && <View style={{ height: 8 }} />}
@@ -502,7 +587,15 @@ export default function GoalScreen({ navigation, route }: GoalProps) {
         <Pressable
           onPress={() => {
             void haptics.tap();
-            setIsEditing(!isEditing);
+            if (isEditing) {
+              resetTaskEditor();
+            } else {
+              setEditingTaskId(null);
+              setTaskTitle("");
+              setFrequency("daily");
+              setCustomFrequency({ type: "weekly", target: 3 });
+              setIsEditing(true);
+            }
           }}
           style={{
             backgroundColor: theme.surface,
@@ -530,7 +623,7 @@ export default function GoalScreen({ navigation, route }: GoalProps) {
           visible={isEditing}
           onRequestClose={() => {
             void haptics.tap();
-            setIsEditing(false);
+            resetTaskEditor();
           }}
         >
           <View
@@ -544,7 +637,7 @@ export default function GoalScreen({ navigation, route }: GoalProps) {
             <Pressable
               onPress={() => {
                 void haptics.tap();
-                setIsEditing(false);
+                resetTaskEditor();
               }}
               style={{
                 position: "absolute",
@@ -564,7 +657,7 @@ export default function GoalScreen({ navigation, route }: GoalProps) {
                 backgroundColor: theme.surface,
               }}
             >
-              <Text style={{ fontWeight: "700", fontSize: 18, color: theme.text }}>New Task</Text>
+              <Text style={{ fontWeight: "700", fontSize: 18, color: theme.text }}>{editingTaskId ? "Edit Task" : "New Task"}</Text>
               <TextInput
                 placeholder="e.g., Take creatine"
                 value={taskTitle}
@@ -685,7 +778,7 @@ export default function GoalScreen({ navigation, route }: GoalProps) {
                 <Pressable
                   onPress={() => {
                     void haptics.tap();
-                    setIsEditing(false);
+                    resetTaskEditor();
                   }}
                   style={{
                     flex: 1,
@@ -699,30 +792,10 @@ export default function GoalScreen({ navigation, route }: GoalProps) {
                   <Text style={{ color: theme.textSecondary, textAlign: "center", fontWeight: "600" }}>Cancel</Text>
                 </Pressable>
                 <Pressable
-                  onPress={() => {
-                    if (taskTitle.trim()) {
-                      void haptics.success();
-                      addTask(
-                        goalId,
-                        taskTitle.trim(),
-                        frequency,
-                        frequency === "custom"
-                          ? {
-                              ...customFrequency,
-                              target: normalizeCustomTarget(customFrequency.target, customFrequency.type),
-                            }
-                          : undefined
-                      );
-                      setTaskTitle("");
-                      setIsEditing(false);
-                      return;
-                    }
-
-                    void haptics.error();
-                  }}
+                  onPress={submitTaskEditor}
                   style={{ flex: 1, backgroundColor: theme.primary, padding: 10, borderRadius: 8 }}
                 >
-                  <Text style={{ color: "white", textAlign: "center", fontWeight: "700" }}>Add</Text>
+                  <Text style={{ color: "white", textAlign: "center", fontWeight: "700" }}>{editingTaskId ? "Save" : "Add"}</Text>
                 </Pressable>
               </View>
               {frequency === "custom" ? (

--- a/store.ts
+++ b/store.ts
@@ -487,6 +487,7 @@ interface State {
     setSelectedDate: (date: Date) => void;
     updateGoal: (goalId: string, updates: { title?: string; target?: string }) => void;
     addTask: (goalId: string, title: string, frequency: Frequency, customFrequency?: CustomFrequency) => void;
+    updateTask: (goalId: string, taskId: string, updates: { title?: string; frequency?: Frequency; customFrequency?: CustomFrequency | undefined }) => void;
     deleteTask: (goalId: string, taskId: string) => void;
     toggleTaskCompletion: (goalId: string, taskId: string, date?: Date) => void;
     completionsByDate: () => Record<string, number>;
@@ -545,6 +546,28 @@ export const useStore = create<State>()(
                                         completions: [] 
                                     },
                                 ],
+                            }
+                            : g
+                    ),
+                })),
+            updateTask: (goalId, taskId, updates) =>
+                set((s) => ({
+                    goals: s.goals.map((g) =>
+                        g.id === goalId
+                            ? {
+                                ...g,
+                                tasks: g.tasks.map((task) =>
+                                    task.id === taskId
+                                        ? {
+                                            ...task,
+                                            title: updates.title ?? task.title,
+                                            frequency: updates.frequency ?? task.frequency,
+                                            customFrequency: (updates.frequency ?? task.frequency) === "custom"
+                                                ? (updates.customFrequency ?? task.customFrequency)
+                                                : undefined,
+                                        }
+                                        : task
+                                ),
                             }
                             : g
                     ),


### PR DESCRIPTION
This is Hugo, Adam’s OpenClaw agent, submitting this PR.

## Summary of changes
- added a store-level `updateTask` action so task title and frequency can be edited without recreating the task
- updated the goal screen task modal so it can switch between add and edit modes
- added edit controls on both pending and completed task cards

## Edge cases / non-goals
- existing task completion history is preserved when editing a task
- custom-frequency tasks keep their custom settings when edited and clear them when switched to a non-custom frequency
- this PR does not implement goal reordering or task drag-and-drop

## Checkout
```bash
git fetch && git checkout hugo/issue-10-edit-tasks
```

Closes #10
