### PR TITLE
Setting up alarming for if you are going to fall behind

### DIFF
--- a/components/GoalScreen.tsx
+++ b/components/GoalScreen.tsx
@@ -3,7 +3,7 @@ import { NativeStackScreenProps } from "@react-navigation/native-stack";
 import { Text, View, Pressable, TextInput, ScrollView, Modal, Alert } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { Ionicons } from "@expo/vector-icons";
-import { useStore, getCustomFrequencyProgress, shouldShowCustomTask } from "../store";
+import { useStore, getCustomFrequencyProgress, getCustomFrequencyAlert, shouldShowCustomTask } from "../store";
 import { useTheme } from "../contexts/ThemeContext";
 import { format, startOfWeek, endOfWeek, isWithinInterval, isToday } from "date-fns";
 import { Frequency, CustomFrequency } from "../types";
@@ -368,6 +368,7 @@ export default function GoalScreen({ navigation, route }: GoalProps) {
                     <Text style={{ fontWeight: "700", color: theme.text }}>{item.title}</Text>
                     {item.frequency === "custom" && item.customFrequency ? (() => {
                       const progress = getCustomFrequencyProgress(item, selectedDate);
+                      const alert = getCustomFrequencyAlert(item, selectedDate);
                       return (
                         <View style={{ marginTop: 8 }}>
                           <Text style={{ color: theme.textSecondary, fontSize: 12, marginBottom: 4 }}>
@@ -391,6 +392,22 @@ export default function GoalScreen({ navigation, route }: GoalProps) {
                               {progress.target - progress.completed} more to go
                             </Text>
                           )}
+                          {alert ? (
+                            <Text
+                              style={{
+                                color: alert.tone === "error"
+                                  ? theme.danger
+                                  : alert.tone === "warning"
+                                    ? theme.warning ?? "#f59e0b"
+                                    : theme.primary,
+                                fontSize: 11,
+                                marginTop: 4,
+                                fontWeight: "600",
+                              }}
+                            >
+                              {alert.message}
+                            </Text>
+                          ) : null}
                         </View>
                       );
                     })() : (() => {

--- a/store.ts
+++ b/store.ts
@@ -2,7 +2,7 @@ import { create } from "zustand";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { persist, createJSONStorage } from "zustand/middleware";
 import { Goal, Frequency, CustomFrequency, Task } from "./types";
-import { format, startOfDay, startOfWeek, endOfWeek, startOfMonth, endOfMonth, isWithinInterval } from "date-fns";
+import { format, startOfDay, startOfWeek, endOfWeek, startOfMonth, endOfMonth, isWithinInterval, differenceInCalendarDays } from "date-fns";
 
 // Date utility functions
 const normalizeDate = (date: Date): Date => startOfDay(date);
@@ -66,6 +66,45 @@ export const shouldShowCustomTask = (task: Task, referenceDate: Date = new Date(
   const completedToday = task.completions.some(date => isSameDay(date, referenceDate));
   const { achieved } = getCustomFrequencyProgress(task, referenceDate);
   return !completedToday && !achieved;
+};
+
+export const getCustomFrequencyAlert = (task: Task, referenceDate: Date = new Date()) => {
+  if (task.frequency !== "custom" || !task.customFrequency) {
+    return null;
+  }
+
+  const progress = getCustomFrequencyProgress(task, referenceDate);
+  const completedToday = task.completions.some(date => isSameDay(date, referenceDate));
+  const remainingNeeded = Math.max(progress.target - progress.completed, 0);
+
+  if (remainingNeeded <= 0 || !progress.periodEnd) {
+    return null;
+  }
+
+  const daysRemaining = differenceInCalendarDays(progress.periodEnd, normalizeDate(referenceDate)) + 1;
+
+  if (remainingNeeded > daysRemaining) {
+    return {
+      tone: "error" as const,
+      message: `You can no longer hit this ${task.customFrequency.type} target in the current period.`,
+    };
+  }
+
+  if (!completedToday && remainingNeeded >= daysRemaining) {
+    return {
+      tone: "warning" as const,
+      message: `Do this today or you will not be able to meet this ${task.customFrequency.type} target.`,
+    };
+  }
+
+  if (remainingNeeded === daysRemaining - 1) {
+    return {
+      tone: "notice" as const,
+      message: `${remainingNeeded} completion${remainingNeeded === 1 ? "" : "s"} left with ${daysRemaining} day${daysRemaining === 1 ? "" : "s"} remaining in this ${task.customFrequency.type} period.`,
+    };
+  }
+
+  return null;
 };
 
 // Helper to calculate streak for any goal type


### PR DESCRIPTION
This is Hugo, Adam’s OpenClaw agent, submitting this PR.

## Summary of changes
- added custom-frequency warning logic for tasks that are at risk of missing their weekly or monthly target
- show inline alerts on pending custom tasks when the target is already impossible, when the user must complete it today, or when the period is getting tight
- kept the warnings tied to the selected date context so the message reflects the day the user is viewing

## Edge cases / non-goals
- no push notifications or system notifications were added in this PR
- the warnings are UI-based and only appear for pending custom-frequency tasks
- this PR does not change how streaks or completion history are calculated

## Checkout
```bash
git fetch && git checkout hugo/issue-11-fall-behind-warning
```

Closes #11
