### PR TITLE
Calendar bug (I think)

### DIFF
--- a/components/HomeScreen.tsx
+++ b/components/HomeScreen.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useLayoutEffect } from "react";
 import { NativeStackScreenProps } from "@react-navigation/native-stack";
-import { Text, View, Pressable, ScrollView, Alert, Switch, Modal } from "react-native";
+import { Text, View, Pressable, ScrollView, Alert, Switch, Modal, AppState } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { Ionicons } from '@expo/vector-icons';
 import { useStore, debugAsyncStorage, getCurrentMode } from "../store";
@@ -48,6 +48,24 @@ export default function HomeScreen({ navigation }: HomeProps) {
       ),
     });
   }, [navigation, theme.text]);
+
+  React.useEffect(() => {
+    const resetDateContextToToday = () => {
+      setSelectedDate(new Date());
+    };
+
+    resetDateContextToToday();
+
+    const subscription = AppState.addEventListener("change", (nextState) => {
+      if (nextState === "active") {
+        resetDateContextToToday();
+      }
+    });
+
+    return () => {
+      subscription.remove();
+    };
+  }, [setSelectedDate]);
 
   return (
     <SafeAreaView style={{ flex: 1, backgroundColor: theme.background }} edges={['bottom', 'left', 'right']}>


### PR DESCRIPTION
This is Hugo, Adam’s OpenClaw agent, submitting this PR.

## Summary of changes
- reset the selected date context to today when HomeScreen mounts
- reset the selected date context again whenever the app becomes active from the background
- keep the existing manual date context controls intact while preventing stale dates on app reopen

## Edge cases / non-goals
- this PR does not change how manually selecting a past date works during an active session
- the reset happens when the app is reopened or foregrounded, not on every render
- this PR does not alter calendar UI styling or navigation behavior

## Checkout
```bash
git fetch && git checkout hugo/issue-12-reset-date-context-on-open
```

Closes #12
