### PR TITLE
Add left and right buttons for date context navigation

### DIFF
--- a/components/DateContextCard.tsx
+++ b/components/DateContextCard.tsx
@@ -7,21 +7,23 @@ import { useTheme } from "../contexts/ThemeContext";
 interface DateContextCardProps {
   selectedDate: Date;
   onPress: () => void;
+  onPreviousDay: () => void;
+  onNextDay: () => void;
 }
 
-export default function DateContextCard({ selectedDate, onPress }: DateContextCardProps) {
+export default function DateContextCard({ selectedDate, onPress, onPreviousDay, onNextDay }: DateContextCardProps) {
   const { theme } = useTheme();
   const viewingToday = isToday(selectedDate);
 
   return (
-    <Pressable
-      onPress={onPress}
+    <View
       style={{
         borderWidth: 1,
         borderColor: theme.primary + "40",
         borderRadius: 14,
         padding: 14,
         backgroundColor: theme.surface,
+        gap: 12,
       }}
     >
       <View style={{ flexDirection: "row", alignItems: "center", justifyContent: "space-between", gap: 12 }}>
@@ -50,8 +52,56 @@ export default function DateContextCard({ selectedDate, onPress }: DateContextCa
             </Text>
           </View>
         </View>
-        <Ionicons name="chevron-forward" size={18} color={theme.textSecondary} />
+        <Pressable
+          onPress={onPress}
+          hitSlop={8}
+          style={{ padding: 4 }}
+        >
+          <Ionicons name="calendar-outline" size={18} color={theme.textSecondary} />
+        </Pressable>
       </View>
-    </Pressable>
+
+      <View style={{ flexDirection: "row", gap: 10 }}>
+        <Pressable
+          onPress={onPreviousDay}
+          style={{
+            flex: 1,
+            flexDirection: "row",
+            alignItems: "center",
+            justifyContent: "center",
+            gap: 6,
+            backgroundColor: theme.background,
+            borderWidth: 1,
+            borderColor: theme.border,
+            borderRadius: 10,
+            paddingVertical: 10,
+          }}
+        >
+          <Ionicons name="chevron-back" size={16} color={theme.text} />
+          <Text style={{ color: theme.text, fontWeight: "700" }}>Previous</Text>
+        </Pressable>
+
+        <Pressable
+          onPress={onNextDay}
+          disabled={viewingToday}
+          style={{
+            flex: 1,
+            flexDirection: "row",
+            alignItems: "center",
+            justifyContent: "center",
+            gap: 6,
+            backgroundColor: theme.background,
+            borderWidth: 1,
+            borderColor: theme.border,
+            borderRadius: 10,
+            paddingVertical: 10,
+            opacity: viewingToday ? 0.45 : 1,
+          }}
+        >
+          <Text style={{ color: theme.text, fontWeight: "700" }}>Next</Text>
+          <Ionicons name="chevron-forward" size={16} color={theme.text} />
+        </Pressable>
+      </View>
+    </View>
   );
 }

--- a/components/HomeScreen.tsx
+++ b/components/HomeScreen.tsx
@@ -3,6 +3,7 @@ import { NativeStackScreenProps } from "@react-navigation/native-stack";
 import { Text, View, Pressable, ScrollView, Alert, Switch, Modal, AppState } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { Ionicons } from '@expo/vector-icons';
+import { addDays, isToday, startOfDay, subDays } from "date-fns";
 import { useStore, debugAsyncStorage, getCurrentMode } from "../store";
 import { useTheme } from "../contexts/ThemeContext";
 import RadarChart from "./RadarChart";
@@ -76,6 +77,21 @@ export default function HomeScreen({ navigation }: HomeProps) {
             onPress={() => {
               void haptics.tap();
               setCalendarVisible(true);
+            }}
+            onPreviousDay={() => {
+              void haptics.tap();
+              setSelectedDate(subDays(selectedDate, 1));
+            }}
+            onNextDay={() => {
+              if (isToday(selectedDate)) {
+                void haptics.warning();
+                return;
+              }
+
+              void haptics.tap();
+              const nextDate = addDays(selectedDate, 1);
+              const today = startOfDay(new Date());
+              setSelectedDate(nextDate > today ? today : nextDate);
             }}
           />
 


### PR DESCRIPTION
This is Hugo, Adam’s OpenClaw agent, submitting this PR.

## Summary of changes
- added explicit Previous and Next buttons to the date context card
- wired the buttons to move the selected date backward and forward by one day
- kept the next-day action clamped to today so users cannot navigate into future dates

## Edge cases / non-goals
- the calendar modal is still available for faster jumps across larger date ranges
- the Next button is disabled when the selected date is already today
- this PR does not redesign the calendar modal itself

## Checkout
```bash
git fetch && git checkout hugo/issue-18-date-context-nav-buttons
```

Closes #18
