### PR TITLE
Add drag-and-drop reordering for goals and tasks

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { NavigationContainer } from "@react-navigation/native";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import { StatusBar } from "expo-status-bar";
+import { GestureHandlerRootView } from "react-native-gesture-handler";
 import { SafeAreaProvider } from "react-native-safe-area-context";
 import { ThemeProvider, useTheme } from "./contexts/ThemeContext";
 import HomeScreen from "./components/HomeScreen";
@@ -52,10 +53,12 @@ function ThemedNavigation() {
 
 export default function App() {
   return (
-    <ThemeProvider>
-      <SafeAreaProvider>
-        <ThemedNavigation />
-      </SafeAreaProvider>
-    </ThemeProvider>
+    <GestureHandlerRootView style={{ flex: 1 }}>
+      <ThemeProvider>
+        <SafeAreaProvider>
+          <ThemedNavigation />
+        </SafeAreaProvider>
+      </ThemeProvider>
+    </GestureHandlerRootView>
   );
 }

--- a/components/DateContextCard.tsx
+++ b/components/DateContextCard.tsx
@@ -7,21 +7,23 @@ import { useTheme } from "../contexts/ThemeContext";
 interface DateContextCardProps {
   selectedDate: Date;
   onPress: () => void;
+  onPreviousDay: () => void;
+  onNextDay: () => void;
 }
 
-export default function DateContextCard({ selectedDate, onPress }: DateContextCardProps) {
+export default function DateContextCard({ selectedDate, onPress, onPreviousDay, onNextDay }: DateContextCardProps) {
   const { theme } = useTheme();
   const viewingToday = isToday(selectedDate);
 
   return (
-    <Pressable
-      onPress={onPress}
+    <View
       style={{
         borderWidth: 1,
         borderColor: theme.primary + "40",
         borderRadius: 14,
         padding: 14,
         backgroundColor: theme.surface,
+        gap: 12,
       }}
     >
       <View style={{ flexDirection: "row", alignItems: "center", justifyContent: "space-between", gap: 12 }}>
@@ -50,8 +52,56 @@ export default function DateContextCard({ selectedDate, onPress }: DateContextCa
             </Text>
           </View>
         </View>
-        <Ionicons name="chevron-forward" size={18} color={theme.textSecondary} />
+        <Pressable
+          onPress={onPress}
+          hitSlop={8}
+          style={{ padding: 4 }}
+        >
+          <Ionicons name="calendar-outline" size={18} color={theme.textSecondary} />
+        </Pressable>
       </View>
-    </Pressable>
+
+      <View style={{ flexDirection: "row", gap: 10 }}>
+        <Pressable
+          onPress={onPreviousDay}
+          style={{
+            flex: 1,
+            flexDirection: "row",
+            alignItems: "center",
+            justifyContent: "center",
+            gap: 6,
+            backgroundColor: theme.background,
+            borderWidth: 1,
+            borderColor: theme.border,
+            borderRadius: 10,
+            paddingVertical: 10,
+          }}
+        >
+          <Ionicons name="chevron-back" size={16} color={theme.text} />
+          <Text style={{ color: theme.text, fontWeight: "700" }}>Previous</Text>
+        </Pressable>
+
+        <Pressable
+          onPress={onNextDay}
+          disabled={viewingToday}
+          style={{
+            flex: 1,
+            flexDirection: "row",
+            alignItems: "center",
+            justifyContent: "center",
+            gap: 6,
+            backgroundColor: theme.background,
+            borderWidth: 1,
+            borderColor: theme.border,
+            borderRadius: 10,
+            paddingVertical: 10,
+            opacity: viewingToday ? 0.45 : 1,
+          }}
+        >
+          <Text style={{ color: theme.text, fontWeight: "700" }}>Next</Text>
+          <Ionicons name="chevron-forward" size={16} color={theme.text} />
+        </Pressable>
+      </View>
+    </View>
   );
 }

--- a/components/GoalScreen.tsx
+++ b/components/GoalScreen.tsx
@@ -3,6 +3,7 @@ import { NativeStackScreenProps } from "@react-navigation/native-stack";
 import { Text, View, Pressable, TextInput, ScrollView, Modal, Alert } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { Ionicons } from "@expo/vector-icons";
+import DraggableFlatList, { RenderItemParams, ScaleDecorator } from "react-native-draggable-flatlist";
 import { useStore, getCustomFrequencyProgress, getCustomFrequencyAlert, shouldShowCustomTask } from "../store";
 import { useTheme } from "../contexts/ThemeContext";
 import { format, startOfWeek, endOfWeek, isWithinInterval, isToday } from "date-fns";
@@ -27,6 +28,7 @@ export default function GoalScreen({ navigation, route }: GoalProps) {
   const addTask = useStore((s) => s.addTask);
   const updateTask = useStore((s) => s.updateTask);
   const updateGoal = useStore((s) => s.updateGoal);
+  const reorderTasks = useStore((s) => s.reorderTasks);
   const deleteTask = useStore((s) => s.deleteTask);
   const toggleTask = useStore((s) => s.toggleTaskCompletion);
   const { theme } = useTheme();
@@ -38,6 +40,7 @@ export default function GoalScreen({ navigation, route }: GoalProps) {
   const [editingTaskId, setEditingTaskId] = React.useState<string | null>(null);
   const [isEditingGoalTitle, setIsEditingGoalTitle] = React.useState(false);
   const [goalTitleDraft, setGoalTitleDraft] = React.useState(goal.title);
+  const [isReorderingTasks, setIsReorderingTasks] = React.useState(false);
 
   if (!goal) return <Text>Not found</Text>;
 
@@ -327,8 +330,78 @@ export default function GoalScreen({ navigation, route }: GoalProps) {
         </View>
 
         {/* Pending Tasks Section */}
-        <Text style={{ fontWeight: "700", marginTop: 4, color: theme.text }}>Tasks</Text>
-        {pendingTasks.length === 0 ? (
+        <View style={{ flexDirection: "row", alignItems: "center", justifyContent: "space-between", marginTop: 4 }}>
+          <Text style={{ fontWeight: "700", color: theme.text }}>Tasks</Text>
+          {goal.tasks.length > 1 ? (
+            <Pressable
+              onPress={() => {
+                setIsReorderingTasks((prev) => !prev);
+                void haptics.tap();
+              }}
+              style={{
+                flexDirection: "row",
+                alignItems: "center",
+                gap: 6,
+                paddingHorizontal: 10,
+                paddingVertical: 6,
+                borderRadius: 9999,
+                borderWidth: 1,
+                borderColor: isReorderingTasks ? theme.primary : theme.border,
+                backgroundColor: theme.surface,
+              }}
+            >
+              <Ionicons name="reorder-three-outline" size={14} color={isReorderingTasks ? theme.primary : theme.textSecondary} />
+              <Text style={{ color: isReorderingTasks ? theme.primary : theme.textSecondary, fontWeight: "600", fontSize: 12 }}>
+                {isReorderingTasks ? "Done" : "Reorder"}
+              </Text>
+            </Pressable>
+          ) : null}
+        </View>
+        {isReorderingTasks ? (
+          <View style={{ marginTop: 8, gap: 8 }}>
+            <Text style={{ color: theme.textSecondary, fontSize: 12 }}>
+              Long press and drag tasks to change their order.
+            </Text>
+            <DraggableFlatList
+              data={goal.tasks}
+              keyExtractor={(item) => item.id}
+              scrollEnabled={false}
+              onDragEnd={({ data }) => {
+                reorderTasks(goalId, data.map((task) => task.id));
+                void haptics.success();
+              }}
+              ItemSeparatorComponent={() => <View style={{ height: 8 }} />}
+              renderItem={({ item, drag, isActive }: RenderItemParams<(typeof goal.tasks)[number]>) => (
+                <ScaleDecorator>
+                  <Pressable
+                    onLongPress={drag}
+                    delayLongPress={150}
+                    style={{
+                      flexDirection: "row",
+                      alignItems: "center",
+                      gap: 10,
+                      padding: 12,
+                      borderWidth: 1,
+                      borderColor: isActive ? theme.primary : theme.border,
+                      borderRadius: 10,
+                      backgroundColor: theme.surface,
+                    }}
+                  >
+                    <Ionicons name="reorder-three-outline" size={18} color={theme.textSecondary} />
+                    <View style={{ flex: 1 }}>
+                      <Text style={{ fontWeight: "700", color: theme.text }}>{item.title}</Text>
+                      <Text style={{ color: theme.textSecondary, fontSize: 12 }}>
+                        {item.frequency === "custom" && item.customFrequency
+                          ? `${item.customFrequency.target} times per ${item.customFrequency.type}`
+                          : `Frequency: ${item.frequency}`}
+                      </Text>
+                    </View>
+                  </Pressable>
+                </ScaleDecorator>
+              )}
+            />
+          </View>
+        ) : pendingTasks.length === 0 ? (
           <View style={{
             padding: 20,
             borderRadius: 12,
@@ -482,7 +555,7 @@ export default function GoalScreen({ navigation, route }: GoalProps) {
         )}
 
         {/* Completed Tasks Section */}
-        {completedTasks.length > 0 ? (
+        {!isReorderingTasks && completedTasks.length > 0 ? (
           <>
             <Text style={{ fontWeight: "700", marginTop: 16, color: theme.textSecondary }}>Completed</Text>
             {completedTasks.map((item, index) => (

--- a/components/HomeScreen.tsx
+++ b/components/HomeScreen.tsx
@@ -4,6 +4,7 @@ import { Text, View, Pressable, ScrollView, Alert, Switch, Modal, AppState } fro
 import { SafeAreaView } from "react-native-safe-area-context";
 import { Ionicons } from '@expo/vector-icons';
 import { addDays, isToday, startOfDay, subDays } from "date-fns";
+import DraggableFlatList, { RenderItemParams, ScaleDecorator } from "react-native-draggable-flatlist";
 import { useStore, debugAsyncStorage, getCurrentMode } from "../store";
 import { useTheme } from "../contexts/ThemeContext";
 import RadarChart from "./RadarChart";
@@ -26,6 +27,7 @@ export default function HomeScreen({ navigation }: HomeProps) {
   const goals = useStore((s) => s.goals);
   const selectedDate = useStore((s) => s.selectedDate);
   const setSelectedDate = useStore((s) => s.setSelectedDate);
+  const reorderGoals = useStore((s) => s.reorderGoals);
   const resetAppData = useStore((s) => s.resetAppData);
   const deleteGoal = useStore((s) => s.deleteGoal);
   const currentMode = getCurrentMode();
@@ -101,64 +103,87 @@ export default function HomeScreen({ navigation }: HomeProps) {
           <Text style={{ fontSize: 18, fontWeight: "700", marginTop: 8, color: theme.text }}>Goals</Text>
           
           {/* Goals list */}
-          {goals.map((goal, index) => (
-            <View key={goal.id}>
-              <View
-                style={{ 
-                  borderWidth: 1, 
-                  borderColor: theme.border, 
-                  borderRadius: 10, 
-                  padding: 12, 
-                  backgroundColor: theme.surface 
+          {goals.length > 0 ? (
+            <>
+              <Text style={{ color: theme.textSecondary, fontSize: 12 }}>
+                Long press and drag goals to reorder them.
+              </Text>
+              <DraggableFlatList
+                data={goals}
+                keyExtractor={(item) => item.id}
+                scrollEnabled={false}
+                onDragEnd={({ data }) => {
+                  reorderGoals(data.map((goal) => goal.id));
+                  void haptics.success();
                 }}
-              >
-                <View style={{ flexDirection: "row", alignItems: "center", gap: 12 }}>
-                  <Pressable
-                    onPress={() => {
-                      void haptics.navigate();
-                      navigation.navigate("Goal", { goalId: goal.id });
-                    }}
-                    style={{ flex: 1 }}
-                  >
-                    <Text style={{ fontSize: 16, fontWeight: "700", color: theme.text }}>{goal.title}</Text>
-                    {goal.target && <Text style={{ color: theme.textSecondary }}>Target: {goal.target}</Text>}
-                    <Text style={{ color: theme.textSecondary }}>Tasks: {goal.tasks.length}</Text>
-                  </Pressable>
+                ItemSeparatorComponent={() => <View style={{ height: 8 }} />}
+                renderItem={({ item, drag, isActive }: RenderItemParams<(typeof goals)[number]>) => (
+                  <ScaleDecorator>
+                    <View
+                      style={{
+                        borderWidth: 1,
+                        borderColor: isActive ? theme.primary : theme.border,
+                        borderRadius: 10,
+                        padding: 12,
+                        backgroundColor: theme.surface,
+                      }}
+                    >
+                      <View style={{ flexDirection: "row", alignItems: "center", gap: 12 }}>
+                        <Pressable
+                          onLongPress={drag}
+                          delayLongPress={150}
+                          style={{ paddingVertical: 4, paddingRight: 2 }}
+                        >
+                          <Ionicons name="reorder-three-outline" size={18} color={theme.textSecondary} />
+                        </Pressable>
+                        <Pressable
+                          onPress={() => {
+                            void haptics.navigate();
+                            navigation.navigate("Goal", { goalId: item.id });
+                          }}
+                          style={{ flex: 1 }}
+                        >
+                          <Text style={{ fontSize: 16, fontWeight: "700", color: theme.text }}>{item.title}</Text>
+                          {item.target && <Text style={{ color: theme.textSecondary }}>Target: {item.target}</Text>}
+                          <Text style={{ color: theme.textSecondary }}>Tasks: {item.tasks.length}</Text>
+                        </Pressable>
 
-                  <Pressable
-                    onPress={() => {
-                      void haptics.warning();
-                      Alert.alert(
-                        "Delete goal?",
-                        `This will remove "${goal.title}" and all its tasks.`,
-                        [
-                          { text: "Cancel", style: "cancel" },
-                          {
-                            text: "Delete",
-                            style: "destructive",
-                            onPress: () => {
-                              void haptics.destructive();
-                              deleteGoal(goal.id);
-                            }
-                          }
-                        ]
-                      );
-                    }}
-                    style={{
-                      alignSelf: "center",
-                      borderRadius: 9999,
-                      paddingHorizontal: 8,
-                      paddingVertical: 4,
-                      opacity: 0.35
-                    }}
-                  >
-                    <Ionicons name="trash-outline" size={16} color={theme.textSecondary} />
-                  </Pressable>
-                </View>
-              </View>
-              {index < goals.length - 1 && <View style={{ height: 8 }} />}
-            </View>
-          ))}
+                        <Pressable
+                          onPress={() => {
+                            void haptics.warning();
+                            Alert.alert(
+                              "Delete goal?",
+                              `This will remove "${item.title}" and all its tasks.`,
+                              [
+                                { text: "Cancel", style: "cancel" },
+                                {
+                                  text: "Delete",
+                                  style: "destructive",
+                                  onPress: () => {
+                                    void haptics.destructive();
+                                    deleteGoal(item.id);
+                                  }
+                                }
+                              ]
+                            );
+                          }}
+                          style={{
+                            alignSelf: "center",
+                            borderRadius: 9999,
+                            paddingHorizontal: 8,
+                            paddingVertical: 4,
+                            opacity: 0.35
+                          }}
+                        >
+                          <Ionicons name="trash-outline" size={16} color={theme.textSecondary} />
+                        </Pressable>
+                      </View>
+                    </View>
+                  </ScaleDecorator>
+                )}
+              />
+            </>
+          ) : null}
 
           <Pressable
             onPress={() => {

--- a/components/HomeScreen.tsx
+++ b/components/HomeScreen.tsx
@@ -34,7 +34,9 @@ export default function HomeScreen({ navigation }: HomeProps) {
   const { theme, isDark, toggleTheme, resetThemePreference } = useTheme();
   const [settingsVisible, setSettingsVisible] = useState(false);
   const [calendarVisible, setCalendarVisible] = useState(false);
+  const [isReorderingGoals, setIsReorderingGoals] = useState(false);
   const isDevToolsVisible = currentMode === "DEV";
+  const canReorderGoals = goals.length > 1;
 
   useLayoutEffect(() => {
     navigation.setOptions({
@@ -70,6 +72,74 @@ export default function HomeScreen({ navigation }: HomeProps) {
     };
   }, [setSelectedDate]);
 
+  const renderGoalCard = (
+    item: (typeof goals)[number],
+    options?: { drag?: () => void; isActive?: boolean; showDragHandle?: boolean }
+  ) => (
+    <View
+      style={{
+        borderWidth: 1,
+        borderColor: options?.isActive ? theme.primary : theme.border,
+        borderRadius: 10,
+        padding: 12,
+        backgroundColor: theme.surface,
+      }}
+    >
+      <View style={{ flexDirection: "row", alignItems: "center", gap: 12 }}>
+        {options?.showDragHandle ? (
+          <Pressable
+            onLongPress={options.drag}
+            delayLongPress={150}
+            style={{ paddingVertical: 4, paddingRight: 2 }}
+          >
+            <Ionicons name="reorder-three-outline" size={18} color={theme.textSecondary} />
+          </Pressable>
+        ) : null}
+        <Pressable
+          onPress={() => {
+            void haptics.navigate();
+            navigation.navigate("Goal", { goalId: item.id });
+          }}
+          style={{ flex: 1 }}
+        >
+          <Text style={{ fontSize: 16, fontWeight: "700", color: theme.text }}>{item.title}</Text>
+          {item.target && <Text style={{ color: theme.textSecondary }}>Target: {item.target}</Text>}
+          <Text style={{ color: theme.textSecondary }}>Tasks: {item.tasks.length}</Text>
+        </Pressable>
+
+        <Pressable
+          onPress={() => {
+            void haptics.warning();
+            Alert.alert(
+              "Delete goal?",
+              `This will remove "${item.title}" and all its tasks.`,
+              [
+                { text: "Cancel", style: "cancel" },
+                {
+                  text: "Delete",
+                  style: "destructive",
+                  onPress: () => {
+                    void haptics.destructive();
+                    deleteGoal(item.id);
+                  }
+                }
+              ]
+            );
+          }}
+          style={{
+            alignSelf: "center",
+            borderRadius: 9999,
+            paddingHorizontal: 8,
+            paddingVertical: 4,
+            opacity: 0.35
+          }}
+        >
+          <Ionicons name="trash-outline" size={16} color={theme.textSecondary} />
+        </Pressable>
+      </View>
+    </View>
+  );
+
   return (
     <SafeAreaView style={{ flex: 1, backgroundColor: theme.background }} edges={['bottom', 'left', 'right']}>
       <ScrollView style={{ flex: 1, backgroundColor: theme.background }} showsVerticalScrollIndicator={false}>
@@ -100,88 +170,71 @@ export default function HomeScreen({ navigation }: HomeProps) {
           <Text style={{ fontSize: 18, fontWeight: "700", color: theme.text }}>Consistency Overview</Text>
           <RadarChart goals={goals} size={250} />
 
-          <Text style={{ fontSize: 18, fontWeight: "700", marginTop: 8, color: theme.text }}>Goals</Text>
+          <View style={{ flexDirection: "row", alignItems: "center", justifyContent: "space-between", marginTop: 8 }}>
+            <Text style={{ fontSize: 18, fontWeight: "700", color: theme.text }}>Goals</Text>
+            {canReorderGoals ? (
+              <Pressable
+                onPress={() => {
+                  setIsReorderingGoals((prev) => !prev);
+                  void haptics.tap();
+                }}
+                style={{
+                  flexDirection: "row",
+                  alignItems: "center",
+                  gap: 6,
+                  paddingHorizontal: 10,
+                  paddingVertical: 6,
+                  borderRadius: 9999,
+                  borderWidth: 1,
+                  borderColor: isReorderingGoals ? theme.primary : theme.border,
+                  backgroundColor: theme.surface,
+                }}
+              >
+                <Ionicons
+                  name="reorder-three-outline"
+                  size={14}
+                  color={isReorderingGoals ? theme.primary : theme.textSecondary}
+                />
+                <Text style={{ color: isReorderingGoals ? theme.primary : theme.textSecondary, fontWeight: "600", fontSize: 12 }}>
+                  {isReorderingGoals ? "Done" : "Reorder"}
+                </Text>
+              </Pressable>
+            ) : null}
+          </View>
           
           {/* Goals list */}
           {goals.length > 0 ? (
             <>
-              <Text style={{ color: theme.textSecondary, fontSize: 12 }}>
-                Long press and drag goals to reorder them.
-              </Text>
-              <DraggableFlatList
-                data={goals}
-                keyExtractor={(item) => item.id}
-                scrollEnabled={false}
-                onDragEnd={({ data }) => {
-                  reorderGoals(data.map((goal) => goal.id));
-                  void haptics.success();
-                }}
-                ItemSeparatorComponent={() => <View style={{ height: 8 }} />}
-                renderItem={({ item, drag, isActive }: RenderItemParams<(typeof goals)[number]>) => (
-                  <ScaleDecorator>
-                    <View
-                      style={{
-                        borderWidth: 1,
-                        borderColor: isActive ? theme.primary : theme.border,
-                        borderRadius: 10,
-                        padding: 12,
-                        backgroundColor: theme.surface,
-                      }}
-                    >
-                      <View style={{ flexDirection: "row", alignItems: "center", gap: 12 }}>
-                        <Pressable
-                          onLongPress={drag}
-                          delayLongPress={150}
-                          style={{ paddingVertical: 4, paddingRight: 2 }}
-                        >
-                          <Ionicons name="reorder-three-outline" size={18} color={theme.textSecondary} />
-                        </Pressable>
-                        <Pressable
-                          onPress={() => {
-                            void haptics.navigate();
-                            navigation.navigate("Goal", { goalId: item.id });
-                          }}
-                          style={{ flex: 1 }}
-                        >
-                          <Text style={{ fontSize: 16, fontWeight: "700", color: theme.text }}>{item.title}</Text>
-                          {item.target && <Text style={{ color: theme.textSecondary }}>Target: {item.target}</Text>}
-                          <Text style={{ color: theme.textSecondary }}>Tasks: {item.tasks.length}</Text>
-                        </Pressable>
-
-                        <Pressable
-                          onPress={() => {
-                            void haptics.warning();
-                            Alert.alert(
-                              "Delete goal?",
-                              `This will remove "${item.title}" and all its tasks.`,
-                              [
-                                { text: "Cancel", style: "cancel" },
-                                {
-                                  text: "Delete",
-                                  style: "destructive",
-                                  onPress: () => {
-                                    void haptics.destructive();
-                                    deleteGoal(item.id);
-                                  }
-                                }
-                              ]
-                            );
-                          }}
-                          style={{
-                            alignSelf: "center",
-                            borderRadius: 9999,
-                            paddingHorizontal: 8,
-                            paddingVertical: 4,
-                            opacity: 0.35
-                          }}
-                        >
-                          <Ionicons name="trash-outline" size={16} color={theme.textSecondary} />
-                        </Pressable>
-                      </View>
+              {isReorderingGoals ? (
+                <View style={{ gap: 8 }}>
+                  <Text style={{ color: theme.textSecondary, fontSize: 12 }}>
+                    Long press and drag goals to reorder them.
+                  </Text>
+                  <DraggableFlatList
+                    data={goals}
+                    keyExtractor={(item) => item.id}
+                    scrollEnabled={false}
+                    onDragEnd={({ data }) => {
+                      reorderGoals(data.map((goal) => goal.id));
+                      void haptics.success();
+                    }}
+                    ItemSeparatorComponent={() => <View style={{ height: 8 }} />}
+                    renderItem={({ item, drag, isActive }: RenderItemParams<(typeof goals)[number]>) => (
+                      <ScaleDecorator>
+                        {renderGoalCard(item, { drag, isActive, showDragHandle: true })}
+                      </ScaleDecorator>
+                    )}
+                  />
+                </View>
+              ) : (
+                <View style={{ gap: 8 }}>
+                  {goals.map((goal) => (
+                    <View key={goal.id}>
+                      {renderGoalCard(goal)}
                     </View>
-                  </ScaleDecorator>
-                )}
-              />
+                  ))}
+                </View>
+              )}
             </>
           ) : null}
 

--- a/components/HomeScreen.tsx
+++ b/components/HomeScreen.tsx
@@ -3,6 +3,7 @@ import { NativeStackScreenProps } from "@react-navigation/native-stack";
 import { Text, View, Pressable, ScrollView, Alert, Switch, Modal, AppState } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { Ionicons } from '@expo/vector-icons';
+import { addDays, isToday, startOfDay, subDays } from "date-fns";
 import { useStore, debugAsyncStorage, getCurrentMode } from "../store";
 import { useTheme } from "../contexts/ThemeContext";
 import RadarChart from "./RadarChart";
@@ -76,6 +77,21 @@ export default function HomeScreen({ navigation }: HomeProps) {
             onPress={() => {
               void haptics.tap();
               setCalendarVisible(true);
+            }}
+            onPreviousDay={() => {
+              void haptics.tap();
+              setSelectedDate(subDays(selectedDate, 1));
+            }}
+            onNextDay={() => {
+              if (isToday(selectedDate)) {
+                void haptics.warning();
+                return;
+              }
+
+              void haptics.tap();
+              const nextDate = addDays(selectedDate, 1);
+              const today = startOfDay(new Date());
+              setSelectedDate(nextDate > today ? today : nextDate);
             }}
           />
 

--- a/index.ts
+++ b/index.ts
@@ -1,3 +1,4 @@
+import "react-native-gesture-handler";
 import { registerRootComponent } from 'expo';
 
 import App from './App';

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "expo-status-bar": "~3.0.9",
         "react": "19.1.0",
         "react-native": "0.81.5",
+        "react-native-draggable-flatlist": "^4.0.3",
         "react-native-gesture-handler": "~2.28.0",
         "react-native-reanimated": "~4.1.1",
         "react-native-safe-area-context": "~5.6.0",
@@ -6731,6 +6732,20 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-native-draggable-flatlist": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/react-native-draggable-flatlist/-/react-native-draggable-flatlist-4.0.3.tgz",
+      "integrity": "sha512-2F4x5BFieWdGq9SetD2nSAR7s7oQCSgNllYgERRXXtNfSOuAGAVbDb/3H3lP0y5f7rEyNwabKorZAD/SyyNbDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/preset-typescript": "^7.17.12"
+      },
+      "peerDependencies": {
+        "react-native": ">=0.64.0",
+        "react-native-gesture-handler": ">=2.0.0",
+        "react-native-reanimated": ">=2.8.0"
       }
     },
     "node_modules/react-native-gesture-handler": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -78,6 +78,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1459,6 +1460,7 @@
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
       "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -2445,6 +2447,7 @@
       "resolved": "https://registry.npmjs.org/@react-navigation/native/-/native-7.2.2.tgz",
       "integrity": "sha512-kem1Ko2BcbAjmbQIv66dNmr6EtfDut3QU0qjsVhMnLLhktwyXb6FzZYp8gTrUb6AvkAbaJoi+BF5Pl55pAUa5w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@react-navigation/core": "^7.17.2",
         "escape-string-regexp": "^4.0.0",
@@ -2604,6 +2607,7 @@
       "integrity": "sha512-Qec1E3mhALmaspIrhWt9jkQMNdw6bReVu64mjvhbhq2NFPftLPVr+l1SZgmw/66WwBNpDh7ao5AT6gF5v41PFA==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -3147,6 +3151,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -3895,6 +3900,7 @@
       "resolved": "https://registry.npmjs.org/expo/-/expo-54.0.33.tgz",
       "integrity": "sha512-3yOEfAKqo+gqHcV8vKcnq0uA5zxlohnhA3fu4G43likN8ct5ZZ3LjAh9wDdKteEkoad3tFPvwxmXW711S5OHUw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.20.0",
         "@expo/cli": "54.0.23",
@@ -3961,6 +3967,7 @@
       "resolved": "https://registry.npmjs.org/expo-font/-/expo-font-14.0.11.tgz",
       "integrity": "sha512-ga0q61ny4s/kr4k8JX9hVH69exVSIfcIc19+qZ7gt71Mqtm7xy2c6kwsPTCyhBW2Ro5yXTT8EaZOpuRi35rHbg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fontfaceobserver": "^2.1.0"
       },
@@ -6645,6 +6652,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
       "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6682,6 +6690,7 @@
       "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.81.5.tgz",
       "integrity": "sha512-1w+/oSjEXZjMqsIvmkCRsOc8UBYv163bTWKTI8+1mxztvQPhCRYGTvZ/PL1w16xXHneIj/SLGfxWg2GWN2uexw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/create-cache-key-function": "^29.7.0",
         "@react-native/assets-registry": "0.81.5",
@@ -6753,6 +6762,7 @@
       "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-2.28.0.tgz",
       "integrity": "sha512-0msfJ1vRxXKVgTgvL+1ZOoYw3/0z1R+Ked0+udoJhyplC2jbVKIJ8Z1bzWdpQRCV3QcQ87Op0zJVE5DhKK2A0A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@egjs/hammerjs": "^2.0.17",
         "hoist-non-react-statics": "^3.3.0",
@@ -6778,6 +6788,7 @@
       "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-4.1.7.tgz",
       "integrity": "sha512-Q4H6xA3Tn7QL0/E/KjI86I1KK4tcf+ErRE04LH34Etka2oVQhW6oXQ+Q8ZcDCVxiWp5vgbBH6XcH8BOo4w/Rhg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "react-native-is-edge-to-edge": "^1.2.1",
         "semver": "^7.7.2"
@@ -6805,6 +6816,7 @@
       "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-5.6.2.tgz",
       "integrity": "sha512-4XGqMNj5qjUTYywJqpdWZ9IG8jgkS3h06sfVjfw5yZQZfWnRFXczi0GnYyFyCc2EBps/qFmoCH8fez//WumdVg==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
@@ -6815,6 +6827,7 @@
       "resolved": "https://registry.npmjs.org/react-native-screens/-/react-native-screens-4.16.0.tgz",
       "integrity": "sha512-yIAyh7F/9uWkOzCi1/2FqvNvK6Wb9Y1+Kzn16SuGfN9YFJDTbwlzGRvePCNTOX0recpLQF3kc2FmvMUhyTCH1Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "react-freeze": "^1.0.0",
         "react-native-is-edge-to-edge": "^1.2.1",
@@ -6845,6 +6858,7 @@
       "resolved": "https://registry.npmjs.org/react-native-worklets/-/react-native-worklets-0.5.1.tgz",
       "integrity": "sha512-lJG6Uk9YuojjEX/tQrCbcbmpdLCSFxDK1rJlkDhgqkVi1KZzG7cdcBFQRqyNOOzR9Y0CXNuldmtWTGOyM0k0+w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/plugin-transform-arrow-functions": "^7.0.0-0",
         "@babel/plugin-transform-class-properties": "^7.0.0-0",
@@ -6977,6 +6991,7 @@
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
       "integrity": "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7855,6 +7870,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7919,6 +7935,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "expo-status-bar": "~3.0.9",
     "react": "19.1.0",
     "react-native": "0.81.5",
+    "react-native-draggable-flatlist": "^4.0.3",
     "react-native-gesture-handler": "~2.28.0",
     "react-native-reanimated": "~4.1.1",
     "react-native-safe-area-context": "~5.6.0",

--- a/store.ts
+++ b/store.ts
@@ -523,10 +523,12 @@ interface State {
     goals: Goal[];
     selectedDate: Date;
     addGoal: (title: string, target?: string) => void;
+    reorderGoals: (goalIdsInOrder: string[]) => void;
     setSelectedDate: (date: Date) => void;
     updateGoal: (goalId: string, updates: { title?: string; target?: string }) => void;
     addTask: (goalId: string, title: string, frequency: Frequency, customFrequency?: CustomFrequency) => void;
     updateTask: (goalId: string, taskId: string, updates: { title?: string; frequency?: Frequency; customFrequency?: CustomFrequency | undefined }) => void;
+    reorderTasks: (goalId: string, taskIdsInOrder: string[]) => void;
     deleteTask: (goalId: string, taskId: string) => void;
     toggleTaskCompletion: (goalId: string, taskId: string, date?: Date) => void;
     completionsByDate: () => Record<string, number>;
@@ -553,6 +555,19 @@ export const useStore = create<State>()(
                         { id: makeId(), title, target, tasks: [], createdAt: Date.now() },
                     ],
                 })),
+            reorderGoals: (goalIdsInOrder) =>
+                set((s) => {
+                    const goalMap = new Map(s.goals.map((goal) => [goal.id, goal]));
+                    const reorderedGoals = goalIdsInOrder
+                        .map((goalId) => goalMap.get(goalId))
+                        .filter((goal): goal is Goal => Boolean(goal));
+
+                    const remainingGoals = s.goals.filter((goal) => !goalIdsInOrder.includes(goal.id));
+
+                    return {
+                        goals: [...reorderedGoals, ...remainingGoals],
+                    };
+                }),
             setSelectedDate: (date) =>
                 set({
                     selectedDate: normalizeDate(date),
@@ -610,6 +625,23 @@ export const useStore = create<State>()(
                             }
                             : g
                     ),
+                })),
+            reorderTasks: (goalId, taskIdsInOrder) =>
+                set((s) => ({
+                    goals: s.goals.map((g) => {
+                        if (g.id !== goalId) return g;
+
+                        const taskMap = new Map(g.tasks.map((task) => [task.id, task]));
+                        const reorderedTasks = taskIdsInOrder
+                            .map((taskId) => taskMap.get(taskId))
+                            .filter((task): task is Task => Boolean(task));
+                        const remainingTasks = g.tasks.filter((task) => !taskIdsInOrder.includes(task.id));
+
+                        return {
+                            ...g,
+                            tasks: [...reorderedTasks, ...remainingTasks],
+                        };
+                    }),
                 })),
             deleteTask: (goalId, taskId) =>
                 set((s) => ({


### PR DESCRIPTION
This is Hugo, Adam’s OpenClaw agent, submitting this PR.

## Summary of changes
- added persistent reorder actions in the Zustand store for both goals and tasks
- made the home goals list draggable with a visible reorder handle and long-press drag interaction
- added a reorder mode inside each goal so tasks can be dragged into a new saved order
- added the drag-and-drop dependency needed for a clear mobile reorder interaction

## Edge cases / non-goals
- reorder controls only appear when there is more than one task in a goal
- task completion history stays attached to each task while order changes
- this PR keeps existing task editing and completion flows, it only adds reordering

## Checkout
```bash
git fetch && git checkout hugo/issue-19-drag-reordering
```

Closes #19
