### PR TITLE
Add current and all-time trend radar modes

### DIFF
--- a/components/HomeScreen.tsx
+++ b/components/HomeScreen.tsx
@@ -11,6 +11,7 @@ import RadarChart from "./RadarChart";
 import DateContextCard from "./DateContextCard";
 import CalendarModal from "./CalendarModal";
 import { haptics } from "../utils/haptics";
+import { RadarChartMode } from "./RadarChart";
 
 type RootStackParamList = {
   Home: undefined;
@@ -35,6 +36,7 @@ export default function HomeScreen({ navigation }: HomeProps) {
   const [settingsVisible, setSettingsVisible] = useState(false);
   const [calendarVisible, setCalendarVisible] = useState(false);
   const [isReorderingGoals, setIsReorderingGoals] = useState(false);
+  const [radarMode, setRadarMode] = useState<RadarChartMode>("current");
   const isDevToolsVisible = currentMode === "DEV";
   const canReorderGoals = goals.length > 1;
 
@@ -168,7 +170,33 @@ export default function HomeScreen({ navigation }: HomeProps) {
           />
 
           <Text style={{ fontSize: 18, fontWeight: "700", color: theme.text }}>Consistency Overview</Text>
-          <RadarChart goals={goals} size={250} referenceDate={selectedDate} />
+          <View style={{ flexDirection: "row", alignItems: "center", gap: 8 }}>
+            {([
+              { key: "current", label: "Current" },
+              { key: "trend", label: "All-time trend" },
+            ] as const).map((option) => (
+              <Pressable
+                key={option.key}
+                onPress={() => {
+                  setRadarMode(option.key);
+                  void haptics.tap();
+                }}
+                style={{
+                  paddingHorizontal: 10,
+                  paddingVertical: 6,
+                  borderRadius: 9999,
+                  borderWidth: 1,
+                  borderColor: radarMode === option.key ? theme.primary : theme.border,
+                  backgroundColor: radarMode === option.key ? theme.primary + "20" : theme.surface,
+                }}
+              >
+                <Text style={{ color: radarMode === option.key ? theme.primary : theme.textSecondary, fontWeight: "600", fontSize: 12 }}>
+                  {option.label}
+                </Text>
+              </Pressable>
+            ))}
+          </View>
+          <RadarChart goals={goals} size={250} referenceDate={selectedDate} mode={radarMode} />
 
           <View style={{ flexDirection: "row", alignItems: "center", justifyContent: "space-between", marginTop: 8 }}>
             <Text style={{ fontSize: 18, fontWeight: "700", color: theme.text }}>Goals</Text>

--- a/components/RadarChart.tsx
+++ b/components/RadarChart.tsx
@@ -2,16 +2,42 @@ import React from "react";
 import { View, Text } from "react-native";
 import Svg, { Polygon, Line, Circle, Text as SvgText } from "react-native-svg";
 import { Goal } from "../types";
-import { endOfDay, isAfter } from "date-fns";
+import { endOfDay, isAfter, isSameDay, isWithinInterval, startOfWeek, endOfWeek, differenceInCalendarDays } from "date-fns";
 import { useTheme } from "../contexts/ThemeContext";
+import { getCustomFrequencyProgress } from "../store";
+
+export type RadarChartMode = "current" | "trend";
 
 interface RadarChartProps {
   goals: Goal[];
   size?: number;
   referenceDate?: Date;
+  mode?: RadarChartMode;
 }
 
-export default function RadarChart({ goals, size = 200, referenceDate = new Date() }: RadarChartProps) {
+const getDailyTrendScore = (completionDates: Date[], startDate: Date, referenceDate: Date) => {
+  const days = Math.max(1, differenceInCalendarDays(referenceDate, startDate) + 1);
+  return Math.min(1, completionDates.length / days);
+};
+
+const getWeeklyTrendScore = (completionDates: Date[], startDate: Date, referenceDate: Date) => {
+  const days = Math.max(1, differenceInCalendarDays(referenceDate, startDate) + 1);
+  const expectedWeeks = Math.max(1, Math.ceil(days / 7));
+  return Math.min(1, completionDates.length / expectedWeeks);
+};
+
+const getCustomTrendScore = (completionDates: Date[], target: number, periodType: "weekly" | "monthly", startDate: Date, referenceDate: Date) => {
+  if (target <= 0) return 0;
+
+  const days = Math.max(1, differenceInCalendarDays(referenceDate, startDate) + 1);
+  const expectedPeriods = periodType === "weekly"
+    ? Math.max(1, Math.ceil(days / 7))
+    : Math.max(1, Math.ceil(days / 30));
+
+  return Math.min(1, completionDates.length / (target * expectedPeriods));
+};
+
+export default function RadarChart({ goals, size = 200, referenceDate = new Date(), mode = "current" }: RadarChartProps) {
   const { theme, isDark } = useTheme();
   
   if (goals.length === 0) {
@@ -57,64 +83,76 @@ export default function RadarChart({ goals, size = 200, referenceDate = new Date
     "#f97316"  // Orange-red
   ];
   
-  // Calculate historical completion percentage for each goal
   const normalizedReferenceDate = endOfDay(referenceDate);
 
   const goalData = goals
     .map((goal) => {
-    const recurringTasks = goal.tasks.filter((task) => task.frequency !== "once");
+      const recurringTasks = goal.tasks.filter((task) => task.frequency !== "once");
 
-    const allCompletionDates = goal.tasks.flatMap((task) =>
-      task.completions.filter((completionDate) => !isAfter(completionDate, normalizedReferenceDate))
-    );
-
-    const firstCompletionDate = allCompletionDates.length > 0
-      ? new Date(Math.min(...allCompletionDates.map((completionDate) => completionDate.getTime())))
-      : null;
-
-    if (!firstCompletionDate) {
-      return null;
-    }
-
-    if (recurringTasks.length === 0) {
-      return { title: goal.title, percentage: 0 };
-    }
-    
-    // Calculate average completion rate across all tasks in this goal
-    let totalCompletionRate = 0;
-    
-    recurringTasks.forEach((task) => {
-      const completionsThroughReferenceDate = task.completions.filter((completionDate) =>
-        !isAfter(completionDate, normalizedReferenceDate)
+      const allCompletionDates = recurringTasks.flatMap((task) =>
+        task.completions.filter((completionDate) => !isAfter(completionDate, normalizedReferenceDate))
       );
 
-      if (completionsThroughReferenceDate.length === 0) {
-        // No completions yet, 0% rate
-        totalCompletionRate += 0;
-      } else {
-        // Calculate how many days this goal has existed
-        const comparisonDate = normalizedReferenceDate.getTime() < firstCompletionDate.getTime()
-          ? firstCompletionDate
-          : normalizedReferenceDate;
-        const daysSinceCreation = Math.max(1, Math.ceil((comparisonDate.getTime() - firstCompletionDate.getTime()) / (1000 * 60 * 60 * 24)));
-        
-        // Calculate completion rate based on frequency
-        let expectedCompletions;
-        if (task.frequency === 'daily') {
-          expectedCompletions = daysSinceCreation;
-        } else if (task.frequency === 'weekly') {
-          expectedCompletions = Math.ceil(daysSinceCreation / 7);
-        } else { // custom
-          expectedCompletions = 1;
-        }
-        
-        // Calculate actual completion rate (cap at 100%)
-        const completionRate = Math.min(1.0, completionsThroughReferenceDate.length / expectedCompletions);
-        totalCompletionRate += completionRate;
+      const firstCompletionDate = allCompletionDates.length > 0
+        ? new Date(Math.min(...allCompletionDates.map((completionDate) => completionDate.getTime())))
+        : null;
+
+      if (!firstCompletionDate) {
+        return null;
       }
-    });
-    
-      const percentage = totalCompletionRate / recurringTasks.length;
+
+      if (recurringTasks.length === 0) {
+        return { title: goal.title, percentage: 0 };
+      }
+
+      const taskScores = recurringTasks.map((task) => {
+        const completionsThroughReferenceDate = task.completions.filter((completionDate) =>
+          !isAfter(completionDate, normalizedReferenceDate)
+        );
+
+        if (completionsThroughReferenceDate.length === 0) {
+          return 0;
+        }
+
+        if (mode === "current") {
+          if (task.frequency === "daily") {
+            return completionsThroughReferenceDate.some((completionDate) => isSameDay(completionDate, normalizedReferenceDate)) ? 1 : 0;
+          }
+
+          if (task.frequency === "weekly") {
+            const weekStart = startOfWeek(normalizedReferenceDate, { weekStartsOn: 0 });
+            const weekEnd = endOfWeek(normalizedReferenceDate, { weekStartsOn: 0 });
+            return completionsThroughReferenceDate.some((completionDate) =>
+              isWithinInterval(completionDate, { start: weekStart, end: weekEnd })
+            ) ? 1 : 0;
+          }
+
+          const progress = getCustomFrequencyProgress(task, normalizedReferenceDate);
+          return progress.target > 0 ? Math.min(1, progress.completed / progress.target) : 0;
+        }
+
+        if (task.frequency === "daily") {
+          return getDailyTrendScore(completionsThroughReferenceDate, firstCompletionDate, normalizedReferenceDate);
+        }
+
+        if (task.frequency === "weekly") {
+          return getWeeklyTrendScore(completionsThroughReferenceDate, firstCompletionDate, normalizedReferenceDate);
+        }
+
+        if (task.customFrequency) {
+          return getCustomTrendScore(
+            completionsThroughReferenceDate,
+            task.customFrequency.target,
+            task.customFrequency.type,
+            firstCompletionDate,
+            normalizedReferenceDate
+          );
+        }
+
+        return 0;
+      });
+
+      const percentage = taskScores.reduce((sum, score) => sum + score, 0) / recurringTasks.length;
       return { title: goal.title, percentage };
     })
     .filter((goal): goal is { title: string; percentage: number } => goal !== null);


### PR DESCRIPTION
This is Hugo, Adam’s OpenClaw agent, submitting this PR.

## Summary of changes
- added a home-screen toggle so users can switch the radar chart between Current and All-time trend modes
- changed Current mode to score recurring tasks against the active period instead of the old rough expected-completions math
- kept a separate all-time trend mode that scores goals using historical completion performance over the full lifetime of the goal since its first completion

## Edge cases / non-goals
- goals still stay hidden from the radar until they have at least one completion to establish a start point
- all-time trend mode is intentionally separate from current active-period completion, so the two views may differ significantly for the same goal
- this PR does not yet persist the selected radar mode across app restarts

## Checkout
```bash
git fetch && git checkout hugo/radar-current-and-trend-modes
```
