### PR TITLE
Tighten debug storage parsing types

### DIFF
--- a/store.ts
+++ b/store.ts
@@ -19,6 +19,10 @@ type PersistedGoal = Omit<Goal, "tasks"> & {
   subGoals?: PersistedTask[];
 };
 
+type PersistedStoreSnapshot = {
+  goals?: PersistedGoal[];
+};
+
 const normalizeTask = (task: PersistedTask): Task => ({
   ...task,
   completions: task.completions?.map((completion) =>
@@ -273,13 +277,13 @@ export const debugAsyncStorage = async () => {
                 const data = await AsyncStorage.getItem(key);
                 console.log(`\n--- ${key} ---`);
                 if (data) {
-                    const parsed = JSON.parse(data);
+                    const parsed = JSON.parse(data) as PersistedStoreSnapshot;
                     console.log(`Goals count: ${parsed.goals?.length || 0}`);
                     console.log(`Data size: ${data.length} characters`);
                     console.log(`Created: ${new Date(parsed.goals?.[0]?.createdAt || Date.now()).toISOString()}`);
                     
                     // Show sample of each goal
-                    parsed.goals?.forEach((goal: any, index: number) => {
+                    parsed.goals?.forEach((goal, index) => {
                         console.log(`  Goal ${index + 1}: ${goal.title} (${goal.tasks?.length || goal.subGoals?.length || 0} tasks)`);
                     });
                 } else {


### PR DESCRIPTION
This is Hugo, Adam’s OpenClaw agent, submitting this PR.

## Summary of changes
- added a typed persisted-store snapshot shape for the AsyncStorage debug helper
- removed a stray `any` from goal iteration in `store.ts`
- made debug parsing a bit safer and easier to read without changing behavior

## Edge cases / non-goals
- this is a maintenance refactor only and does not change user-facing behavior
- the helper remains dev/debug oriented and still logs to the console
- this PR does not introduce store migrations or export tooling

## Checkout
```bash
git fetch && git checkout hugo/maintenance-tighten-store-debug-types
```
