### PR TITLE
Add a once-task heatmap per goal

### DIFF
--- a/components/OverviewScreen.tsx
+++ b/components/OverviewScreen.tsx
@@ -41,6 +41,10 @@ export default function OverviewScreen({ navigation, route }: OverviewProps) {
   };
 
   const recurringTasks = goal.tasks.filter((task) => task.frequency !== "once");
+  const onceTasks = goal.tasks.filter((task) => task.frequency === "once");
+  const onceTaskHeatmapData = getHeatmapData(onceTasks.flatMap((task) => task.completions));
+  const onceTaskCompletionCount = Object.values(onceTaskHeatmapData).reduce((sum, count) => sum + count, 0);
+  const hasOnceTaskHistory = onceTaskCompletionCount > 0;
 
   return (
     <SafeAreaView style={{ flex: 1, backgroundColor: theme.background }} edges={['bottom', 'left', 'right']}>
@@ -65,7 +69,7 @@ export default function OverviewScreen({ navigation, route }: OverviewProps) {
           >
             <Text style={{ fontSize: 16, fontWeight: "700", color: theme.text }}>No recurring tasks yet</Text>
             <Text style={{ color: theme.textSecondary, lineHeight: 22 }}>
-              Consistency charts only apply to daily, weekly, and custom tasks. One-off tasks are treated as one-and-done, so they do not appear in heatmaps or streak views.
+              Recurring charts apply to daily, weekly, and custom tasks. One-off tasks are shown separately below in a combined support-work heatmap when they exist.
             </Text>
           </View>
         ) : null}
@@ -196,6 +200,52 @@ export default function OverviewScreen({ navigation, route }: OverviewProps) {
             {index < recurringTasks.length - 1 && <View style={{ height: 16 }} />}
           </View>
         ))}
+
+        {onceTasks.length > 0 ? (
+          <View
+            style={{
+              borderWidth: 1,
+              borderColor: theme.border,
+              borderRadius: 10,
+              padding: 12,
+              backgroundColor: theme.surface,
+              gap: 10,
+            }}
+          >
+            <View>
+              <Text style={{ fontSize: 16, fontWeight: "700", color: theme.text }}>One-off task history</Text>
+              <Text style={{ color: theme.textSecondary, fontSize: 14, lineHeight: 20 }}>
+                One-off tasks
+              </Text>
+            </View>
+
+            <Text style={{ color: theme.textSecondary, fontSize: 13 }}>
+              Once tasks in this goal: {onceTasks.length} • Completed one-off tasks: {onceTaskCompletionCount}
+            </Text>
+
+            {hasOnceTaskHistory ? (
+              <Heatmap
+                startOffsetDays={180}
+                values={onceTaskHeatmapData}
+                referenceDate={selectedDate}
+              />
+            ) : (
+              <View
+                style={{
+                  borderWidth: 1,
+                  borderColor: theme.border,
+                  borderRadius: 10,
+                  padding: 12,
+                  backgroundColor: theme.background,
+                }}
+              >
+                <Text style={{ color: theme.textSecondary, lineHeight: 20 }}>
+                  No completed one-off tasks yet for this goal.
+                </Text>
+              </View>
+            )}
+          </View>
+        ) : null}
       </ScrollView>
     </SafeAreaView>
   );

--- a/overviewScreen.test.tsx
+++ b/overviewScreen.test.tsx
@@ -1,0 +1,97 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import OverviewScreen from './components/OverviewScreen';
+
+jest.mock('@expo/vector-icons', () => ({
+  Ionicons: 'Ionicons',
+}));
+
+jest.mock('react-native-svg', () => ({
+  __esModule: true,
+  default: 'Svg',
+  Circle: 'Circle',
+}));
+
+jest.mock('react-native-safe-area-context', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return {
+    SafeAreaView: ({ children }: { children: React.ReactNode }) => <View>{children}</View>,
+  };
+});
+
+jest.mock('./components/Heatmap', () => {
+  const React = require('react');
+  const { Text } = require('react-native');
+  return function MockHeatmap() {
+    return <Text testID="heatmap">heatmap</Text>;
+  };
+});
+
+jest.mock('./contexts/ThemeContext', () => ({
+  useTheme: () => ({
+    theme: {
+      background: '#000',
+      surface: '#111',
+      text: '#fff',
+      textSecondary: '#aaa',
+      border: '#333',
+      primary: '#0af',
+    },
+  }),
+}));
+
+const mockState = {
+  selectedDate: new Date('2026-05-06T00:00:00.000Z'),
+  goals: [
+    {
+      id: 'goal-1',
+      title: 'Fitness',
+      createdAt: Date.now(),
+      tasks: [
+        {
+          id: 'recurring-1',
+          title: 'Walk',
+          frequency: 'daily' as const,
+          completions: [new Date('2026-05-05T00:00:00.000Z')],
+        },
+        {
+          id: 'once-1',
+          title: 'Buy shoes',
+          frequency: 'once' as const,
+          completions: [new Date('2026-05-04T00:00:00.000Z')],
+        },
+        {
+          id: 'once-2',
+          title: 'Book physio',
+          frequency: 'once' as const,
+          completions: [new Date('2026-05-03T00:00:00.000Z')],
+        },
+      ],
+    },
+  ],
+};
+
+jest.mock('./store', () => ({
+  useStore: (selector: (state: typeof mockState) => unknown) => selector(mockState),
+  getCustomFrequencyProgress: () => ({ completed: 0, target: 1, achieved: false }),
+  getGoalStreak: () => 0,
+}));
+
+describe('OverviewScreen', () => {
+  it('renders one combined heatmap for all one-off tasks in a goal', () => {
+    const { getAllByTestId, getByText, queryByText } = render(
+      <OverviewScreen
+        navigation={{} as never}
+        route={{ key: 'Consistency-1', name: 'Consistency', params: { goalId: 'goal-1' } } as never}
+      />,
+    );
+
+    expect(getByText('One-off task history')).toBeTruthy();
+    expect(getByText(/grouped into a single combined heatmap/i)).toBeTruthy();
+    expect(getAllByTestId('heatmap')).toHaveLength(2);
+    expect(getByText('Walk')).toBeTruthy();
+    expect(queryByText('Buy shoes')).toBeNull();
+    expect(queryByText('Book physio')).toBeNull();
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -86,6 +86,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1467,6 +1468,7 @@
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
       "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -2796,6 +2798,7 @@
       "resolved": "https://registry.npmjs.org/@react-navigation/native/-/native-7.2.2.tgz",
       "integrity": "sha512-kem1Ko2BcbAjmbQIv66dNmr6EtfDut3QU0qjsVhMnLLhktwyXb6FzZYp8gTrUb6AvkAbaJoi+BF5Pl55pAUa5w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@react-navigation/core": "^7.17.2",
         "escape-string-regexp": "^4.0.0",
@@ -3342,6 +3345,7 @@
       "integrity": "sha512-Qec1E3mhALmaspIrhWt9jkQMNdw6bReVu64mjvhbhq2NFPftLPVr+l1SZgmw/66WwBNpDh7ao5AT6gF5v41PFA==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -4159,6 +4163,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -5332,6 +5337,7 @@
       "resolved": "https://registry.npmjs.org/expo/-/expo-54.0.33.tgz",
       "integrity": "sha512-3yOEfAKqo+gqHcV8vKcnq0uA5zxlohnhA3fu4G43likN8ct5ZZ3LjAh9wDdKteEkoad3tFPvwxmXW711S5OHUw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.20.0",
         "@expo/cli": "54.0.23",
@@ -5398,6 +5404,7 @@
       "resolved": "https://registry.npmjs.org/expo-font/-/expo-font-14.0.11.tgz",
       "integrity": "sha512-ga0q61ny4s/kr4k8JX9hVH69exVSIfcIc19+qZ7gt71Mqtm7xy2c6kwsPTCyhBW2Ro5yXTT8EaZOpuRi35rHbg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fontfaceobserver": "^2.1.0"
       },
@@ -6617,6 +6624,7 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -9524,6 +9532,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
       "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9561,6 +9570,7 @@
       "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.81.5.tgz",
       "integrity": "sha512-1w+/oSjEXZjMqsIvmkCRsOc8UBYv163bTWKTI8+1mxztvQPhCRYGTvZ/PL1w16xXHneIj/SLGfxWg2GWN2uexw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/create-cache-key-function": "^29.7.0",
         "@react-native/assets-registry": "0.81.5",
@@ -9638,6 +9648,7 @@
       "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-2.28.0.tgz",
       "integrity": "sha512-0msfJ1vRxXKVgTgvL+1ZOoYw3/0z1R+Ked0+udoJhyplC2jbVKIJ8Z1bzWdpQRCV3QcQ87Op0zJVE5DhKK2A0A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@egjs/hammerjs": "^2.0.17",
         "hoist-non-react-statics": "^3.3.0",
@@ -9663,6 +9674,7 @@
       "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-4.1.7.tgz",
       "integrity": "sha512-Q4H6xA3Tn7QL0/E/KjI86I1KK4tcf+ErRE04LH34Etka2oVQhW6oXQ+Q8ZcDCVxiWp5vgbBH6XcH8BOo4w/Rhg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "react-native-is-edge-to-edge": "^1.2.1",
         "semver": "^7.7.2"
@@ -9690,6 +9702,7 @@
       "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-5.6.2.tgz",
       "integrity": "sha512-4XGqMNj5qjUTYywJqpdWZ9IG8jgkS3h06sfVjfw5yZQZfWnRFXczi0GnYyFyCc2EBps/qFmoCH8fez//WumdVg==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
@@ -9700,6 +9713,7 @@
       "resolved": "https://registry.npmjs.org/react-native-screens/-/react-native-screens-4.16.0.tgz",
       "integrity": "sha512-yIAyh7F/9uWkOzCi1/2FqvNvK6Wb9Y1+Kzn16SuGfN9YFJDTbwlzGRvePCNTOX0recpLQF3kc2FmvMUhyTCH1Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "react-freeze": "^1.0.0",
         "react-native-is-edge-to-edge": "^1.2.1",
@@ -9730,6 +9744,7 @@
       "resolved": "https://registry.npmjs.org/react-native-worklets/-/react-native-worklets-0.5.1.tgz",
       "integrity": "sha512-lJG6Uk9YuojjEX/tQrCbcbmpdLCSFxDK1rJlkDhgqkVi1KZzG7cdcBFQRqyNOOzR9Y0CXNuldmtWTGOyM0k0+w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/plugin-transform-arrow-functions": "^7.0.0-0",
         "@babel/plugin-transform-class-properties": "^7.0.0-0",
@@ -9862,6 +9877,7 @@
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
       "integrity": "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9872,6 +9888,7 @@
       "integrity": "sha512-jXkSl3CpvPYEF+p/eGDLB4sPoDX8pKkYvRl9+rR8HxLY0X04vW7hCm1/0zHoUSjPZ3bDa+wXWNTDVIw/R8aDVw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "react-is": "^19.1.0",
         "scheduler": "^0.26.0"
@@ -10912,6 +10929,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -11005,6 +11023,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"


### PR DESCRIPTION
This is Hugo, Adam’s OpenClaw agent, submitting this PR.

## Summary of changes
- added a dedicated one-off task heatmap section to the goal consistency screen
- aggregate once-task completions by day at the goal level so support work is visible over time
- kept the one-off heatmap visually separate from recurring consistency heatmaps
- added a clean empty state when a goal has one-off tasks but no completed one-off history yet

## Edge cases / non-goals
- this PR does not add streaks for one-off tasks, since they are not recurring behavior
- the one-off heatmap counts completed once tasks by day across the goal rather than showing a separate heatmap per task
- recurring task heatmaps and behavior are unchanged

## Checkout
```bash
git fetch && git checkout hugo/issue-52-once-task-heatmap
```

Closes #52
