### PR TITLE
Add backup export flow for beta testers

### DIFF
--- a/components/HomeScreen.tsx
+++ b/components/HomeScreen.tsx
@@ -5,7 +5,9 @@ import { SafeAreaView } from "react-native-safe-area-context";
 import { Ionicons } from '@expo/vector-icons';
 import { addDays, isToday, startOfDay, subDays } from "date-fns";
 import DraggableFlatList, { RenderItemParams, ScaleDecorator } from "react-native-draggable-flatlist";
-import { useStore, debugAsyncStorage, getCurrentMode, getCustomFrequencyProgress } from "../store";
+import * as FileSystem from "expo-file-system/legacy";
+import * as Sharing from "expo-sharing";
+import { useStore, debugAsyncStorage, exportBackupData, getCurrentMode, getCustomFrequencyProgress } from "../store";
 import { useTheme } from "../contexts/ThemeContext";
 import RadarChart from "./RadarChart";
 import DateContextCard from "./DateContextCard";
@@ -37,8 +39,50 @@ export default function HomeScreen({ navigation }: HomeProps) {
   const [calendarVisible, setCalendarVisible] = useState(false);
   const [isReorderingGoals, setIsReorderingGoals] = useState(false);
   const [radarMode, setRadarMode] = useState<RadarChartMode>("current");
+  const [isExportingBackup, setIsExportingBackup] = useState(false);
   const isDevToolsVisible = currentMode === "DEV";
   const canReorderGoals = goals.length > 1;
+
+  const handleExportBackup = async () => {
+    if (isExportingBackup) {
+      return;
+    }
+
+    try {
+      setIsExportingBackup(true);
+      await haptics.tap();
+
+      const backup = await exportBackupData();
+      const backupDirectory = `${FileSystem.cacheDirectory}backups/`;
+      const fileUri = `${backupDirectory}ontrack-backup-${backup.exportedAt.replace(/[:.]/g, "-")}.json`;
+
+      await FileSystem.makeDirectoryAsync(backupDirectory, { intermediates: true });
+      await FileSystem.writeAsStringAsync(fileUri, JSON.stringify(backup, null, 2));
+
+      const canShare = await Sharing.isAvailableAsync();
+
+      if (!canShare) {
+        throw new Error("Sharing is not available on this device.");
+      }
+
+      await Sharing.shareAsync(fileUri, {
+        mimeType: "application/json",
+        dialogTitle: "Share OnTrack backup",
+        UTI: "public.json",
+      });
+
+      await haptics.success();
+    } catch (error) {
+      console.error("Error exporting backup:", error);
+      await haptics.warning();
+      Alert.alert(
+        "Backup export failed",
+        "We couldn’t prepare a shareable backup file on this device. Please try again."
+      );
+    } finally {
+      setIsExportingBackup(false);
+    }
+  };
 
   useLayoutEffect(() => {
     navigation.setOptions({
@@ -452,6 +496,28 @@ export default function HomeScreen({ navigation }: HomeProps) {
               <Text style={{ color: theme.text, fontWeight: "600", fontSize: 16 }}>Privacy & Data</Text>
               <Text style={{ color: theme.textSecondary, marginTop: 4 }}>
                 Goals and completion history stay on this device.
+              </Text>
+            </Pressable>
+
+            <Pressable
+              onPress={() => {
+                void handleExportBackup();
+              }}
+              style={{
+                backgroundColor: theme.background,
+                padding: 12,
+                borderRadius: 10,
+                marginBottom: 20,
+                borderWidth: 1,
+                borderColor: theme.border,
+                opacity: isExportingBackup ? 0.7 : 1,
+              }}
+            >
+              <Text style={{ color: theme.text, fontWeight: "600", fontSize: 16 }}>
+                {isExportingBackup ? "Preparing backup..." : "Export backup"}
+              </Text>
+              <Text style={{ color: theme.textSecondary, marginTop: 4 }}>
+                Create a shareable JSON backup of your goals and history for beta testing support.
               </Text>
             </Pressable>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,8 +15,10 @@
         "date-fns": "^4.1.0",
         "expo": "~54.0.33",
         "expo-constants": "~18.0.13",
+        "expo-file-system": "^55.0.17",
         "expo-font": "~14.0.11",
         "expo-haptics": "~15.0.8",
+        "expo-sharing": "^55.0.18",
         "expo-status-bar": "~3.0.9",
         "react": "19.1.0",
         "react-native": "0.81.5",
@@ -33,6 +35,7 @@
       "devDependencies": {
         "@testing-library/jest-native": "^5.4.3",
         "@testing-library/react-native": "^13.3.3",
+        "@types/jest": "^30.0.0",
         "@types/react": "~19.1.0",
         "@types/uuid": "^10.0.0",
         "babel-preset-expo": "^55.0.17",
@@ -2168,6 +2171,30 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/@jest/pattern": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.0.1.tgz",
+      "integrity": "sha512-gWp7NfQW27LaBQz3TITS8L7ZCQ0TLvtmI//4OwlQRx4rnWxcPNIYjxZpDcN4+UlGxgm3jS5QPz8IPTCkb59wZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "jest-regex-util": "30.0.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/pattern/node_modules/jest-regex-util": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.0.1.tgz",
+      "integrity": "sha512-jHEQgBXAgc+Gh4g0p3bCevgRCVRkB4VB70zhoAE48gxeSr1hfUOsM/C2WoJgVL7Eyg//hudYENbm3Ne+/dRVVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
     "node_modules/@jest/reporters": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-29.7.0.tgz",
@@ -3057,6 +3084,237 @@
       "dependencies": {
         "@types/istanbul-lib-report": "*"
       }
+    },
+    "node_modules/@types/jest": {
+      "version": "30.0.0",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-30.0.0.tgz",
+      "integrity": "sha512-XTYugzhuwqWjws0CVz8QpM36+T+Dz5mTEBKhNs/esGLnCIlGdRy+Dq78NRjd7ls7r8BC8ZRMOrKlkO1hU0JOwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "expect": "^30.0.0",
+        "pretty-format": "^30.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/@jest/expect-utils": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.3.0.tgz",
+      "integrity": "sha512-j0+W5iQQ8hBh7tHZkTQv3q2Fh/M7Je72cIsYqC4OaktgtO7v1So9UTjp6uPBHIaB6beoF/RRsCgMJKvti0wADA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/get-type": "30.1.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/@jest/schemas": {
+      "version": "30.0.5",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.0.5.tgz",
+      "integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.34.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/@jest/types": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.3.0.tgz",
+      "integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/pattern": "30.0.1",
+        "@jest/schemas": "30.0.5",
+        "@types/istanbul-lib-coverage": "^2.0.6",
+        "@types/istanbul-reports": "^3.0.4",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.33",
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/@sinclair/typebox": {
+      "version": "0.34.49",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.49.tgz",
+      "integrity": "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/jest/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@types/jest/node_modules/ci-info": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+      "integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@types/jest/node_modules/expect": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-30.3.0.tgz",
+      "integrity": "sha512-1zQrciTiQfRdo7qJM1uG4navm8DayFa2TgCSRlzUyNkhcJ6XUZF3hjnpkyr3VhAqPH7i/9GkG7Tv5abz6fqz0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/expect-utils": "30.3.0",
+        "@jest/get-type": "30.1.0",
+        "jest-matcher-utils": "30.3.0",
+        "jest-message-util": "30.3.0",
+        "jest-mock": "30.3.0",
+        "jest-util": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/jest-diff": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.3.0.tgz",
+      "integrity": "sha512-n3q4PDQjS4LrKxfWB3Z5KNk1XjXtZTBwQp71OP0Jo03Z6V60x++K5L8k6ZrW8MY8pOFylZvHM0zsjS1RqlHJZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/diff-sequences": "30.3.0",
+        "@jest/get-type": "30.1.0",
+        "chalk": "^4.1.2",
+        "pretty-format": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/jest-matcher-utils": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.3.0.tgz",
+      "integrity": "sha512-HEtc9uFQgaUHkC7nLSlQL3Tph4Pjxt/yiPvkIrrDCt9jhoLIgxaubo1G+CFOnmHYMxHwwdaSN7mkIFs6ZK8OhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/get-type": "30.1.0",
+        "chalk": "^4.1.2",
+        "jest-diff": "30.3.0",
+        "pretty-format": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/jest-message-util": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.3.0.tgz",
+      "integrity": "sha512-Z/j4Bo+4ySJ+JPJN3b2Qbl9hDq3VrXmnjjGEWD/x0BCXeOXPTV1iZYYzl2X8c1MaCOL+ewMyNBcm88sboE6YWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@jest/types": "30.3.0",
+        "@types/stack-utils": "^2.0.3",
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "picomatch": "^4.0.3",
+        "pretty-format": "30.3.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.6"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/jest-mock": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.3.0.tgz",
+      "integrity": "sha512-OTzICK8CpE+t4ndhKrwlIdbM6Pn8j00lvmSmq5ejiO+KxukbLjgOflKWMn3KE34EZdQm5RqTuKj+5RIEniYhog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "jest-util": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/jest-util": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.3.0.tgz",
+      "integrity": "sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "ci-info": "^4.2.0",
+        "graceful-fs": "^4.2.11",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/@types/jest/node_modules/pretty-format": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.3.0.tgz",
+      "integrity": "sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "30.0.5",
+        "ansi-styles": "^5.2.0",
+        "react-is": "^18.3.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/jsdom": {
       "version": "20.0.1",
@@ -5136,6 +5394,16 @@
         "react-native": "*"
       }
     },
+    "node_modules/expo-file-system": {
+      "version": "55.0.17",
+      "resolved": "https://registry.npmjs.org/expo-file-system/-/expo-file-system-55.0.17.tgz",
+      "integrity": "sha512-d27K1cagUOt2BwxwPka9KW8Znu5kN1tnairozCzzCRZviZFtWnBxwFuJ3KU6MAbav/9UhSMkp5Ve/oZ+SR0UgQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "react-native": "*"
+      }
+    },
     "node_modules/expo-font": {
       "version": "14.0.11",
       "resolved": "https://registry.npmjs.org/expo-font/-/expo-font-14.0.11.tgz",
@@ -5195,6 +5463,72 @@
       "license": "MIT",
       "engines": {
         "node": ">=20.16.0"
+      }
+    },
+    "node_modules/expo-sharing": {
+      "version": "55.0.18",
+      "resolved": "https://registry.npmjs.org/expo-sharing/-/expo-sharing-55.0.18.tgz",
+      "integrity": "sha512-Tqy4LXRLw/UEg5mT7BKhx8y4ReNz8fVldvhHJV5cesH3kRgEerHkYxVwid2vd7v34KnNp0RH1OqUyDlzZTQ9AQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/config-plugins": "^55.0.8",
+        "@expo/config-types": "^55.0.5",
+        "@expo/plist": "^0.5.2"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/expo-sharing/node_modules/@expo/config-plugins": {
+      "version": "55.0.8",
+      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-55.0.8.tgz",
+      "integrity": "sha512-8WfWTRntTCcowfOS+tHdB0z98gKetTwktg4G5TWkCkXVa8Jt1NUnvzaaU4UHk2vbR2U4N84RyZJFizSwfF6C9g==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/config-types": "^55.0.5",
+        "@expo/json-file": "~10.0.13",
+        "@expo/plist": "^0.5.2",
+        "@expo/sdk-runtime-versions": "^1.0.0",
+        "chalk": "^4.1.2",
+        "debug": "^4.3.5",
+        "getenv": "^2.0.0",
+        "glob": "^13.0.0",
+        "resolve-from": "^5.0.0",
+        "semver": "^7.5.4",
+        "slugify": "^1.6.6",
+        "xcode": "^3.0.1",
+        "xml2js": "0.6.0"
+      }
+    },
+    "node_modules/expo-sharing/node_modules/@expo/config-types": {
+      "version": "55.0.5",
+      "resolved": "https://registry.npmjs.org/@expo/config-types/-/config-types-55.0.5.tgz",
+      "integrity": "sha512-sCmSUZG4mZ/ySXvfyyBdhjivz8Q539X1NondwDdYG7s3SBsk+wsgPJzYsqgAG/P9+l0xWjUD2F+kQ1cAJ6NNLg==",
+      "license": "MIT"
+    },
+    "node_modules/expo-sharing/node_modules/@expo/plist": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@expo/plist/-/plist-0.5.2.tgz",
+      "integrity": "sha512-o4xdVdBpe4aTl3sPMZ2u3fJH4iG1I768EIRk1xRZP+GaFI93MaR3JvoFibYqxeTmLQ1p1kNEVqylfUjezxx45g==",
+      "license": "MIT",
+      "dependencies": {
+        "@xmldom/xmldom": "^0.8.8",
+        "base64-js": "^1.5.1",
+        "xmlbuilder": "^15.1.1"
+      }
+    },
+    "node_modules/expo-sharing/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/expo-status-bar": {

--- a/package.json
+++ b/package.json
@@ -17,8 +17,10 @@
     "date-fns": "^4.1.0",
     "expo": "~54.0.33",
     "expo-constants": "~18.0.13",
+    "expo-file-system": "^55.0.17",
     "expo-font": "~14.0.11",
     "expo-haptics": "~15.0.8",
+    "expo-sharing": "^55.0.18",
     "expo-status-bar": "~3.0.9",
     "react": "19.1.0",
     "react-native": "0.81.5",
@@ -35,6 +37,7 @@
   "devDependencies": {
     "@testing-library/jest-native": "^5.4.3",
     "@testing-library/react-native": "^13.3.3",
+    "@types/jest": "^30.0.0",
     "@types/react": "~19.1.0",
     "@types/uuid": "^10.0.0",
     "babel-preset-expo": "^55.0.17",

--- a/store.test.ts
+++ b/store.test.ts
@@ -1,4 +1,4 @@
-import { getCustomFrequencyProgress } from './store';
+import { createBackupPayload, getCustomFrequencyProgress } from './store';
 import { Task } from './types';
 
 describe('getCustomFrequencyProgress', () => {
@@ -43,5 +43,36 @@ describe('getCustomFrequencyProgress', () => {
     expect(progress.completed).toBe(4);
     expect(progress.target).toBe(5);
     expect(progress.achieved).toBe(false);
+  });
+});
+
+describe('createBackupPayload', () => {
+  it('serializes dates and includes export metadata', () => {
+    const payload = createBackupPayload(
+      [
+        {
+          id: 'goal-1',
+          title: 'Fitness',
+          target: 'Stay consistent',
+          createdAt: 1710000000000,
+          tasks: [
+            {
+              id: 'task-1',
+              title: 'Workout',
+              frequency: 'daily',
+              completions: [new Date('2026-04-22T12:00:00.000Z')],
+            },
+          ],
+        },
+      ],
+      new Date('2026-04-21T12:00:00.000Z'),
+      new Date('2026-04-22T15:30:00.000Z')
+    );
+
+    expect(payload.exportedAt).toBe('2026-04-22T15:30:00.000Z');
+    expect(payload.mode).toBe('PROD');
+    expect(payload.storageKey).toBe('ontrack-store-prod');
+    expect(payload.selectedDate).toBe('2026-04-21T04:00:00.000Z');
+    expect(payload.goals[0].tasks[0].completions).toEqual(['2026-04-22T12:00:00.000Z']);
   });
 });

--- a/store.ts
+++ b/store.ts
@@ -19,6 +19,26 @@ type PersistedGoal = Omit<Goal, "tasks"> & {
   subGoals?: PersistedTask[];
 };
 
+export interface BackupPayload {
+  exportedAt: string;
+  storageKey: string;
+  mode: "DEV" | "PROD";
+  selectedDate: string;
+  goals: Array<{
+    id: string;
+    title: string;
+    target?: string;
+    createdAt: number;
+    tasks: Array<{
+      id: string;
+      title: string;
+      frequency: Frequency;
+      customFrequency?: CustomFrequency;
+      completions: string[];
+    }>;
+  }>;
+}
+
 const normalizeTask = (task: PersistedTask): Task => ({
   ...task,
   completions: task.completions?.map((completion) =>
@@ -30,6 +50,35 @@ const normalizeGoal = (goal: PersistedGoal): Goal => ({
   ...goal,
   tasks: (goal.tasks ?? goal.subGoals ?? []).map(normalizeTask),
 });
+
+export const createBackupPayload = (
+  goals: Goal[],
+  selectedDate: Date,
+  exportedAt: Date = new Date()
+): BackupPayload => ({
+  exportedAt: exportedAt.toISOString(),
+  storageKey: ACTIVE_STORAGE_KEY,
+  mode: CURRENT_MODE,
+  selectedDate: normalizeDate(selectedDate).toISOString(),
+  goals: goals.map((goal) => ({
+    id: goal.id,
+    title: goal.title,
+    target: goal.target,
+    createdAt: goal.createdAt,
+    tasks: goal.tasks.map((task) => ({
+      id: task.id,
+      title: task.title,
+      frequency: task.frequency,
+      customFrequency: task.customFrequency,
+      completions: task.completions.map((completion) => completion.toISOString()),
+    })),
+  })),
+});
+
+export const exportBackupData = async (): Promise<BackupPayload> => {
+  const state = useStore.getState();
+  return createBackupPayload(state.goals, state.selectedDate);
+};
 
 // Helper functions for custom frequency calculations
 export const getCustomFrequencyProgress = (task: Task, referenceDate: Date = new Date()) => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "expo/tsconfig.base",
   "compilerOptions": {
-    "strict": true
+    "strict": true,
+    "types": ["jest"]
   }
 }


### PR DESCRIPTION
This is Hugo, Adam’s OpenClaw agent, submitting this PR.

## Summary
- add a Settings backup export flow that packages the current store into a shareable JSON file
- serialize goals, tasks, completions, and export metadata into a stable backup payload
- add a regression test for backup serialization and validate the change with tests and TypeScript

## Edge cases
- disables repeated taps while a backup file is being prepared
- shows an alert if the device cannot prepare or share the backup file
- normalizes the selected date in the export metadata so the backup reflects the app’s date-context behavior

## Validation
- `npm test -- --runInBand`
- `npx tsc --noEmit`

## Checkout
```bash
git fetch origin
git checkout hugo/issue-41-backup-data
```
