### PR TITLE
Add first-run introduction wizard

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -13,6 +13,7 @@ import OverviewScreen from "./components/OverviewScreen";
 import PrivacyScreen from "./components/PrivacyScreen";
 import InstructionsScreen from "./components/InstructionsScreen";
 import IntroductionWizard from "./components/IntroductionWizard";
+import { ONBOARDING_STORAGE_KEY, shouldShowOnboarding } from "./onboarding";
 import { useStore } from "./store";
 
 type RootStackParamList = {
@@ -25,7 +26,6 @@ type RootStackParamList = {
 };
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
-const ONBOARDING_STORAGE_KEY = "ontrack-onboarding-complete";
 
 function ThemedNavigation() {
   const { theme, isDark } = useTheme();
@@ -47,7 +47,12 @@ function ThemedNavigation() {
         return;
       }
 
-      if (hasCompletedOnboarding || hasExistingGoals) {
+      const shouldIntroduceUser = shouldShowOnboarding({
+        hasCompletedOnboarding: Boolean(hasCompletedOnboarding),
+        hasExistingGoals,
+      });
+
+      if (!shouldIntroduceUser) {
         setShowIntroduction(false);
         setHasCheckedIntroduction(true);
         return;
@@ -74,7 +79,7 @@ function ThemedNavigation() {
     return null;
   }
 
-  if (showIntroduction && goals.length > 0) {
+  if (showIntroduction) {
     return (
       <>
         <IntroductionWizard onDone={handleIntroductionDone} />

--- a/App.tsx
+++ b/App.tsx
@@ -4,6 +4,7 @@ import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import { StatusBar } from "expo-status-bar";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
 import { SafeAreaProvider } from "react-native-safe-area-context";
+import AsyncStorage from "@react-native-async-storage/async-storage";
 import { ThemeProvider, useTheme } from "./contexts/ThemeContext";
 import HomeScreen from "./components/HomeScreen";
 import GoalScreen from "./components/GoalScreen";
@@ -11,6 +12,8 @@ import NewGoalScreen from "./components/NewGoalScreen";
 import OverviewScreen from "./components/OverviewScreen";
 import PrivacyScreen from "./components/PrivacyScreen";
 import InstructionsScreen from "./components/InstructionsScreen";
+import IntroductionWizard from "./components/IntroductionWizard";
+import { useStore } from "./store";
 
 type RootStackParamList = {
   Home: undefined;
@@ -22,9 +25,63 @@ type RootStackParamList = {
 };
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
+const ONBOARDING_STORAGE_KEY = "ontrack-onboarding-complete";
 
 function ThemedNavigation() {
   const { theme, isDark } = useTheme();
+  const goals = useStore((s) => s.goals);
+  const seedDemoData = useStore((s) => s.seedDemoData);
+  const [showIntroduction, setShowIntroduction] = React.useState(false);
+  const [hasCheckedIntroduction, setHasCheckedIntroduction] = React.useState(false);
+
+  React.useEffect(() => {
+    let isCancelled = false;
+
+    const hydrateIntroductionState = async () => {
+      await useStore.persist.rehydrate();
+
+      const hasCompletedOnboarding = await AsyncStorage.getItem(ONBOARDING_STORAGE_KEY);
+      const hasExistingGoals = useStore.getState().goals.length > 0;
+
+      if (isCancelled) {
+        return;
+      }
+
+      if (hasCompletedOnboarding || hasExistingGoals) {
+        setShowIntroduction(false);
+        setHasCheckedIntroduction(true);
+        return;
+      }
+
+      seedDemoData();
+      setShowIntroduction(true);
+      setHasCheckedIntroduction(true);
+    };
+
+    void hydrateIntroductionState();
+
+    return () => {
+      isCancelled = true;
+    };
+  }, [seedDemoData]);
+
+  const handleIntroductionDone = React.useCallback(async () => {
+    await AsyncStorage.setItem(ONBOARDING_STORAGE_KEY, "true");
+    setShowIntroduction(false);
+  }, []);
+
+  if (!hasCheckedIntroduction) {
+    return null;
+  }
+
+  if (showIntroduction && goals.length > 0) {
+    return (
+      <>
+        <IntroductionWizard onDone={handleIntroductionDone} />
+        <StatusBar style={isDark ? "light" : "dark"} />
+      </>
+    );
+  }
   
   return (
     <NavigationContainer>

--- a/components/IntroductionWizard.tsx
+++ b/components/IntroductionWizard.tsx
@@ -18,6 +18,12 @@ type IntroductionWizardProps = {
 
 const slides: Slide[] = [
   {
+    key: "welcome",
+    title: "Welcome! Let’s get you On Track",
+    text: "This quick walkthrough will show you how the app works using demo goals and sample progress, so everything makes sense right away.",
+    icon: "rocket-outline",
+  },
+  {
     key: "goals",
     title: "Goals are the big picture",
     text: "Each goal is something you care about improving. Under each goal, add small repeatable tasks that actually move it forward.",
@@ -37,9 +43,9 @@ const slides: Slide[] = [
   },
   {
     key: "reset",
-    title: "Reset when you are ready",
-    text: "After exploring, open Settings and tap Reset App Data to clear the demo goals and start fresh with your own tracking.",
-    icon: "refresh-outline",
+    title: "IMPORTANT! Reset when you are ready",
+    text: "These are intro goals so you can see how OnTrack is set up. When you are done exploring, open Settings and tap Reset App Data to clear the demo data and start fresh.",
+    icon: "warning-outline",
   },
 ];
 

--- a/components/IntroductionWizard.tsx
+++ b/components/IntroductionWizard.tsx
@@ -1,0 +1,107 @@
+import React from "react";
+import { View, Text, Pressable } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { Ionicons } from "@expo/vector-icons";
+import AppIntroSlider from "react-native-app-intro-slider";
+import { useTheme } from "../contexts/ThemeContext";
+
+type Slide = {
+  key: string;
+  title: string;
+  text: string;
+  icon: keyof typeof Ionicons.glyphMap;
+};
+
+type IntroductionWizardProps = {
+  onDone: () => void;
+};
+
+const slides: Slide[] = [
+  {
+    key: "goals",
+    title: "Goals are the big picture",
+    text: "Each goal is something you care about improving. Under each goal, add small repeatable tasks that actually move it forward.",
+    icon: "flag-outline",
+  },
+  {
+    key: "frequencies",
+    title: "Tasks can repeat in different ways",
+    text: "Daily, weekly, custom weekly or monthly targets, and one-off tasks all behave differently so the app matches real life habits.",
+    icon: "repeat-outline",
+  },
+  {
+    key: "demo",
+    title: "Start by exploring demo data",
+    text: "New users get example goals, tasks, and history so the charts and consistency views make sense immediately instead of feeling empty.",
+    icon: "sparkles-outline",
+  },
+  {
+    key: "reset",
+    title: "Reset when you are ready",
+    text: "After exploring, open Settings and tap Reset App Data to clear the demo goals and start fresh with your own tracking.",
+    icon: "refresh-outline",
+  },
+];
+
+export default function IntroductionWizard({ onDone }: IntroductionWizardProps) {
+  const { theme } = useTheme();
+
+  return (
+    <SafeAreaView style={{ flex: 1, backgroundColor: theme.background }}>
+      <AppIntroSlider
+        data={slides}
+        onDone={onDone}
+        renderItem={({ item }) => (
+          <View style={{ flex: 1, padding: 24, justifyContent: "center", alignItems: "center", gap: 24 }}>
+            <View
+              style={{
+                width: 96,
+                height: 96,
+                borderRadius: 48,
+                alignItems: "center",
+                justifyContent: "center",
+                backgroundColor: theme.surface,
+                borderWidth: 1,
+                borderColor: theme.border,
+              }}
+            >
+              <Ionicons name={item.icon} size={42} color={theme.primary} />
+            </View>
+
+            <View style={{ gap: 12, alignItems: "center" }}>
+              <Text style={{ color: theme.text, fontSize: 28, fontWeight: "800", textAlign: "center" }}>{item.title}</Text>
+              <Text style={{ color: theme.textSecondary, fontSize: 16, lineHeight: 24, textAlign: "center" }}>{item.text}</Text>
+            </View>
+          </View>
+        )}
+        activeDotStyle={{ backgroundColor: theme.primary, width: 24 }}
+        dotStyle={{ backgroundColor: theme.border }}
+        renderNextButton={() => (
+          <View style={{ paddingHorizontal: 8, paddingVertical: 6 }}>
+            <Text style={{ color: theme.primary, fontWeight: "700" }}>Next</Text>
+          </View>
+        )}
+        renderDoneButton={() => (
+          <Pressable
+            onPress={onDone}
+            style={{
+              backgroundColor: theme.primary,
+              borderRadius: 999,
+              paddingHorizontal: 16,
+              paddingVertical: 10,
+            }}
+          >
+            <Text style={{ color: theme.background, fontWeight: "700" }}>Open OnTrack</Text>
+          </Pressable>
+        )}
+        showSkipButton
+        renderSkipButton={() => (
+          <View style={{ paddingHorizontal: 8, paddingVertical: 6 }}>
+            <Text style={{ color: theme.textSecondary, fontWeight: "600" }}>Skip</Text>
+          </View>
+        )}
+        onSkip={onDone}
+      />
+    </SafeAreaView>
+  );
+}

--- a/onboarding.test.ts
+++ b/onboarding.test.ts
@@ -1,0 +1,30 @@
+import { shouldShowOnboarding } from "./onboarding";
+
+describe("shouldShowOnboarding", () => {
+  it("shows onboarding for a true first launch", () => {
+    expect(
+      shouldShowOnboarding({
+        hasCompletedOnboarding: false,
+        hasExistingGoals: false,
+      })
+    ).toBe(true);
+  });
+
+  it("skips onboarding after the walkthrough was already completed", () => {
+    expect(
+      shouldShowOnboarding({
+        hasCompletedOnboarding: true,
+        hasExistingGoals: false,
+      })
+    ).toBe(false);
+  });
+
+  it("skips onboarding for users who already have persisted goals", () => {
+    expect(
+      shouldShowOnboarding({
+        hasCompletedOnboarding: false,
+        hasExistingGoals: true,
+      })
+    ).toBe(false);
+  });
+});

--- a/onboarding.ts
+++ b/onboarding.ts
@@ -1,0 +1,9 @@
+export const ONBOARDING_STORAGE_KEY = "ontrack-onboarding-complete";
+
+export const shouldShowOnboarding = ({
+  hasCompletedOnboarding,
+  hasExistingGoals,
+}: {
+  hasCompletedOnboarding: boolean;
+  hasExistingGoals: boolean;
+}) => !hasCompletedOnboarding && !hasExistingGoals;

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "expo-status-bar": "~3.0.9",
         "react": "19.1.0",
         "react-native": "0.81.5",
+        "react-native-app-intro-slider": "^4.0.4",
         "react-native-draggable-flatlist": "^4.0.3",
         "react-native-gesture-handler": "~2.28.0",
         "react-native-reanimated": "~4.1.1",
@@ -9355,6 +9356,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/react-native-app-intro-slider": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/react-native-app-intro-slider/-/react-native-app-intro-slider-4.0.4.tgz",
+      "integrity": "sha512-Zkjaol6X3BbZkHUpVDj2LjdidpS6rCgKi0fx80xgGKa0pHxBRd4swWTv2bHnnvu5k1/HXwYk0mY2TbK+2jHl5w==",
+      "license": "MIT"
     },
     "node_modules/react-native-draggable-flatlist": {
       "version": "4.0.3",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "expo-status-bar": "~3.0.9",
     "react": "19.1.0",
     "react-native": "0.81.5",
+    "react-native-app-intro-slider": "^4.0.4",
     "react-native-draggable-flatlist": "^4.0.3",
     "react-native-gesture-handler": "~2.28.0",
     "react-native-reanimated": "~4.1.1",

--- a/store.test.ts
+++ b/store.test.ts
@@ -1,4 +1,4 @@
-import { getCustomFrequencyProgress } from './store';
+import { getCustomFrequencyProgress, getSampleGoals } from './store';
 import { Task } from './types';
 
 describe('getCustomFrequencyProgress', () => {
@@ -43,5 +43,19 @@ describe('getCustomFrequencyProgress', () => {
     expect(progress.completed).toBe(4);
     expect(progress.target).toBe(5);
     expect(progress.achieved).toBe(false);
+  });
+});
+
+describe('getSampleGoals', () => {
+  it('includes some demo completions for today so first-launch progress is visible', () => {
+    const todayKey = new Date().toDateString();
+    const goals = getSampleGoals();
+
+    const todayCompletionCount = goals
+      .flatMap((goal) => goal.tasks)
+      .flatMap((task) => task.completions)
+      .filter((completion) => completion.toDateString() === todayKey).length;
+
+    expect(todayCompletionCount).toBeGreaterThan(0);
   });
 });

--- a/store.ts
+++ b/store.ts
@@ -306,7 +306,7 @@ function makeId() {
 }
 
 // Sample data for development/testing
-function getSampleGoals(): Goal[] {
+export function getSampleGoals(): Goal[] {
     return [
         {
             id: makeId(),
@@ -533,6 +533,7 @@ interface State {
     toggleTaskCompletion: (goalId: string, taskId: string, date?: Date) => void;
     completionsByDate: () => Record<string, number>;
     deleteGoal: (goalId: string) => void;
+    seedDemoData: () => void;
     resetAppData: () => void;
 }
 
@@ -702,6 +703,18 @@ export const useStore = create<State>()(
                 set((s) => ({
                     goals: s.goals.filter((g) => g.id !== goalId),
                 }));
+            },
+            seedDemoData: () => {
+                set((s) => {
+                    if (s.goals.length > 0) {
+                        return s;
+                    }
+
+                    return {
+                        goals: getSampleGoals(),
+                        selectedDate: normalizeDate(new Date()),
+                    };
+                });
             },
             resetAppData: () => {
                 set({

--- a/store.ts
+++ b/store.ts
@@ -307,6 +307,9 @@ function makeId() {
 
 // Sample data for development/testing
 export function getSampleGoals(): Goal[] {
+    const today = normalizeDate(new Date());
+    const daysAgo = (days: number) => normalizeDate(new Date(today.getFullYear(), today.getMonth(), today.getDate() - days));
+
     return [
         {
             id: makeId(),
@@ -319,9 +322,13 @@ export function getSampleGoals(): Goal[] {
                     title: "Morning workout",
                     frequency: "daily",
                     completions: [
-                        // 7-day streak ending today (Sept 26-Oct 2, 2025)
-                        new Date(2025, 8, 26), new Date(2025, 8, 27), new Date(2025, 8, 28), 
-                        new Date(2025, 8, 29), new Date(2025, 8, 30), new Date(2025, 9, 1), new Date(2025, 9, 2),
+                        today,
+                        daysAgo(1),
+                        daysAgo(2),
+                        daysAgo(3),
+                        daysAgo(4),
+                        daysAgo(5),
+                        daysAgo(6),
                         // Some earlier scattered completions
                         new Date(2025, 8, 20), new Date(2025, 8, 22), new Date(2025, 8, 24),
                         new Date(2025, 8, 15), new Date(2025, 8, 17), new Date(2025, 8, 19),
@@ -345,8 +352,7 @@ export function getSampleGoals(): Goal[] {
                     frequency: "custom",
                     customFrequency: { type: "weekly", target: 3 },
                     completions: [
-                        // Current week (Sept 30-Oct 6): 2/3 so far
-                        new Date(2025, 8, 30), new Date(2025, 9, 2),
+                        today, daysAgo(2),
                         // Week 4 (Sept 23-29): 3/3 ✓
                         new Date(2025, 8, 23), new Date(2025, 8, 25), new Date(2025, 8, 27),
                         // Week 3 (Sept 16-22): 3/3 ✓
@@ -364,7 +370,7 @@ export function getSampleGoals(): Goal[] {
                     customFrequency: { type: "weekly", target: 2 },
                     completions: [
                         // Current week: 1/2 so far
-                        new Date(2025, 9, 1),
+                        daysAgo(1),
                         // 3-week streak of hitting 2/week
                         new Date(2025, 8, 23), new Date(2025, 8, 26),
                         new Date(2025, 8, 16), new Date(2025, 8, 19),
@@ -377,7 +383,7 @@ export function getSampleGoals(): Goal[] {
                     frequency: "weekly",
                     completions: [
                         // 7-week streak! Each completion is one per week
-                        new Date(2025, 8, 28),  // Current week (Sept 28-Oct 4) - Sunday
+                        daysAgo(3),
                         new Date(2025, 8, 21),  // Week of Sept 21-27
                         new Date(2025, 8, 14),  // Week of Sept 14-20
                         new Date(2025, 8, 7),   // Week of Sept 7-13
@@ -399,6 +405,9 @@ export function getSampleGoals(): Goal[] {
                     title: "Duolingo practice",
                     frequency: "daily",
                     completions: [
+                        today,
+                        daysAgo(1),
+                        daysAgo(2),
                         new Date(2025, 6, 15), new Date(2025, 6, 16), new Date(2025, 6, 17), new Date(2025, 6, 18), new Date(2025, 6, 19),
                         new Date(2025, 6, 20), new Date(2025, 6, 21), new Date(2025, 6, 22), new Date(2025, 6, 23), new Date(2025, 6, 24),
                         new Date(2025, 6, 25), new Date(2025, 6, 26), new Date(2025, 6, 27), new Date(2025, 6, 28), new Date(2025, 6, 29),
@@ -442,6 +451,7 @@ export function getSampleGoals(): Goal[] {
                     title: "Drink 8 glasses of water",
                     frequency: "daily",
                     completions: [
+                        today,
                         new Date("2025-08-02"), new Date("2025-08-15"), new Date("2025-09-01"), new Date("2025-09-20")
                     ]
                 },
@@ -450,7 +460,7 @@ export function getSampleGoals(): Goal[] {
                     title: "Meditate for 10 minutes",
                     frequency: "daily",
                     completions: [
-                        new Date("2025-08-10"), new Date("2025-09-05")
+                        daysAgo(1), new Date("2025-08-10"), new Date("2025-09-05")
                     ]
                 },
                 {
@@ -475,7 +485,7 @@ export function getSampleGoals(): Goal[] {
                     frequency: "daily",
                     completions: [
                         // 3-day streak ending today
-                        new Date(2025, 8, 30), new Date(2025, 9, 1), new Date(2025, 9, 2),
+                        today, daysAgo(1), daysAgo(2),
                         // Some scattered earlier dates
                         new Date("2025-09-25"), new Date("2025-09-26"), new Date("2025-09-28"),
                         new Date("2025-09-20"), new Date("2025-09-22"),


### PR DESCRIPTION
This is Hugo, Adam’s OpenClaw agent, submitting this PR.

## Summary
- add a first-run introduction wizard using `react-native-app-intro-slider`
- seed demo goals and history for brand new users so the app is explorable immediately
- mark onboarding complete after the walkthrough so returning users go straight into the app

## Edge cases
- existing users with stored goals skip the intro instead of being forced through demo onboarding
- demo data is only seeded when the store is empty, so it does not overwrite real user data
- the last intro step explicitly tells users to reset app data from Settings when they are ready to start for real

## Validation
- `npm test -- --runInBand`
- `npx tsc --noEmit`

## Checkout
```bash
git fetch origin
git checkout hugo/issue-3-introduction-wizard
```
