### PR TITLE
Refactor shared informational section cards

### DIFF
--- a/components/InfoSection.tsx
+++ b/components/InfoSection.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+import { Text, View } from "react-native";
+import { useTheme } from "../contexts/ThemeContext";
+
+type InfoSectionProps = {
+  title: string;
+  body: string[];
+};
+
+const sectionStyle = {
+  borderWidth: 1,
+  borderRadius: 12,
+  padding: 14,
+  gap: 8,
+} as const;
+
+export default function InfoSection({ title, body }: InfoSectionProps) {
+  const { theme } = useTheme();
+
+  return (
+    <View style={{ ...sectionStyle, borderColor: theme.border, backgroundColor: theme.surface }}>
+      <Text style={{ fontSize: 16, fontWeight: "700", color: theme.text }}>{title}</Text>
+      {body.map((paragraph) => (
+        <Text key={paragraph} style={{ color: theme.textSecondary, lineHeight: 22 }}>
+          {paragraph}
+        </Text>
+      ))}
+    </View>
+  );
+}

--- a/components/InstructionsScreen.tsx
+++ b/components/InstructionsScreen.tsx
@@ -2,13 +2,52 @@ import React from "react";
 import { Text, View, ScrollView } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useTheme } from "../contexts/ThemeContext";
+import InfoSection from "./InfoSection";
 
-const sectionStyle = {
-  borderWidth: 1,
-  borderRadius: 12,
-  padding: 14,
-  gap: 8,
-} as const;
+const sections = [
+  {
+    title: "1. Build a goal from tasks",
+    body: [
+      "A goal is the outcome you care about, like fitness, recovery, or learning. Tasks are the actions that support it.",
+      "Example: a Fitness goal might include Daily water, Workout 3 times a week, and a 10k run once a month.",
+    ],
+  },
+  {
+    title: "2. Pick the date you want to view",
+    body: [
+      "The date card on the home screen controls the app’s current tracking day. Tap it to open the calendar, switch to a past day, and then mark tasks for that day.",
+      "This is useful for backfilling missed check-ins or logging progress from before you installed the app.",
+    ],
+  },
+  {
+    title: "3. Understand task frequencies",
+    body: [
+      "Daily tasks can be completed once per day. Weekly tasks need one completion during the current Sunday-to-Saturday week. Custom tasks use calendar-based weekly or monthly targets, such as 3 times per week or once per month.",
+      "One-off tasks are different: they are single completions, so they appear separately from recurring consistency habits.",
+    ],
+  },
+  {
+    title: "4. Read the heatmaps",
+    body: [
+      "Heatmaps show when completions happened over time. More highlighted days means you showed up more consistently.",
+      "Open a goal and tap See Consistency to view task-level heatmaps. Recurring tasks each get their own heatmap, while one-off tasks are grouped into a single combined heatmap at the bottom of the page.",
+    ],
+  },
+  {
+    title: "5. Read the radar chart",
+    body: [
+      "The radar chart on the home screen gives a high-level comparison across goals. Bigger values mean that goal has been completed more consistently relative to its task expectations.",
+      "It is useful for spotting which areas of your life are strong and which goals are falling behind.",
+    ],
+  },
+  {
+    title: "6. Example data and reset",
+    body: [
+      "New users may see example goals and tasks so the charts and consistency pages make sense immediately. They are there to teach the flow, not to stay forever.",
+      "When you are ready to start with your own data, open Settings and use Reset App Data. That clears the examples and your local history on this device.",
+    ],
+  },
+] as const;
 
 export default function InstructionsScreen() {
   const { theme } = useTheme();
@@ -23,65 +62,9 @@ export default function InstructionsScreen() {
           </Text>
         </View>
 
-        <View style={{ ...sectionStyle, borderColor: theme.border, backgroundColor: theme.surface }}>
-          <Text style={{ fontSize: 16, fontWeight: "700", color: theme.text }}>1. Build a goal from tasks</Text>
-          <Text style={{ color: theme.textSecondary, lineHeight: 22 }}>
-            A goal is the outcome you care about, like fitness, recovery, or learning. Tasks are the actions that support it.
-          </Text>
-          <Text style={{ color: theme.textSecondary, lineHeight: 22 }}>
-            Example: a Fitness goal might include Daily water, Workout 3 times a week, and a 10k run once a month.
-          </Text>
-        </View>
-
-        <View style={{ ...sectionStyle, borderColor: theme.border, backgroundColor: theme.surface }}>
-          <Text style={{ fontSize: 16, fontWeight: "700", color: theme.text }}>2. Pick the date you want to view</Text>
-          <Text style={{ color: theme.textSecondary, lineHeight: 22 }}>
-            The date card on the home screen controls the app’s current tracking day. Tap it to open the calendar, switch to a past day, and then mark tasks for that day.
-          </Text>
-          <Text style={{ color: theme.textSecondary, lineHeight: 22 }}>
-            This is useful for backfilling missed check-ins or logging progress from before you installed the app.
-          </Text>
-        </View>
-
-        <View style={{ ...sectionStyle, borderColor: theme.border, backgroundColor: theme.surface }}>
-          <Text style={{ fontSize: 16, fontWeight: "700", color: theme.text }}>3. Understand task frequencies</Text>
-          <Text style={{ color: theme.textSecondary, lineHeight: 22 }}>
-            Daily tasks can be completed once per day. Weekly tasks need one completion during the current Sunday-to-Saturday week. Custom tasks use calendar-based weekly or monthly targets, such as 3 times per week or once per month.
-          </Text>
-          <Text style={{ color: theme.textSecondary, lineHeight: 22 }}>
-            One-off tasks are different: they are single completions, so they appear separately from recurring consistency habits.
-          </Text>
-        </View>
-
-        <View style={{ ...sectionStyle, borderColor: theme.border, backgroundColor: theme.surface }}>
-          <Text style={{ fontSize: 16, fontWeight: "700", color: theme.text }}>4. Read the heatmaps</Text>
-          <Text style={{ color: theme.textSecondary, lineHeight: 22 }}>
-            Heatmaps show when completions happened over time. More highlighted days means you showed up more consistently.
-          </Text>
-          <Text style={{ color: theme.textSecondary, lineHeight: 22 }}>
-            Open a goal and tap See Consistency to view task-level heatmaps. Recurring tasks each get their own heatmap, while one-off tasks are grouped into a single combined heatmap at the bottom of the page.
-          </Text>
-        </View>
-
-        <View style={{ ...sectionStyle, borderColor: theme.border, backgroundColor: theme.surface }}>
-          <Text style={{ fontSize: 16, fontWeight: "700", color: theme.text }}>5. Read the radar chart</Text>
-          <Text style={{ color: theme.textSecondary, lineHeight: 22 }}>
-            The radar chart on the home screen gives a high-level comparison across goals. Bigger values mean that goal has been completed more consistently relative to its task expectations.
-          </Text>
-          <Text style={{ color: theme.textSecondary, lineHeight: 22 }}>
-            It is useful for spotting which areas of your life are strong and which goals are falling behind.
-          </Text>
-        </View>
-
-        <View style={{ ...sectionStyle, borderColor: theme.border, backgroundColor: theme.surface }}>
-          <Text style={{ fontSize: 16, fontWeight: "700", color: theme.text }}>6. Example data and reset</Text>
-          <Text style={{ color: theme.textSecondary, lineHeight: 22 }}>
-            New users may see example goals and tasks so the charts and consistency pages make sense immediately. They are there to teach the flow, not to stay forever.
-          </Text>
-          <Text style={{ color: theme.textSecondary, lineHeight: 22 }}>
-            When you are ready to start with your own data, open Settings and use Reset App Data. That clears the examples and your local history on this device.
-          </Text>
-        </View>
+        {sections.map((section) => (
+          <InfoSection key={section.title} title={section.title} body={[...section.body]} />
+        ))}
       </ScrollView>
     </SafeAreaView>
   );

--- a/components/PrivacyScreen.tsx
+++ b/components/PrivacyScreen.tsx
@@ -2,6 +2,28 @@ import React from "react";
 import { Text, View, ScrollView } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useTheme } from "../contexts/ThemeContext";
+import InfoSection from "./InfoSection";
+
+const sections = [
+  {
+    title: "What the app stores",
+    body: [
+      "Goal titles, optional targets, task frequency settings, completion history, and your theme preference.",
+    ],
+  },
+  {
+    title: "What the app does not do",
+    body: [
+      "OnTrack does not require an account, does not include advertising, and does not send your goal data to a server from this app build.",
+    ],
+  },
+  {
+    title: "Managing your data",
+    body: [
+      "You can remove the data stored by the app at any time from Settings by using Reset App Data.",
+    ],
+  },
+] as const;
 
 export default function PrivacyScreen() {
   const { theme } = useTheme();
@@ -16,26 +38,9 @@ export default function PrivacyScreen() {
           </Text>
         </View>
 
-        <View style={{ borderWidth: 1, borderColor: theme.border, borderRadius: 12, padding: 14, backgroundColor: theme.surface, gap: 8 }}>
-          <Text style={{ fontSize: 16, fontWeight: "700", color: theme.text }}>What the app stores</Text>
-          <Text style={{ color: theme.textSecondary, lineHeight: 22 }}>
-            Goal titles, optional targets, task frequency settings, completion history, and your theme preference.
-          </Text>
-        </View>
-
-        <View style={{ borderWidth: 1, borderColor: theme.border, borderRadius: 12, padding: 14, backgroundColor: theme.surface, gap: 8 }}>
-          <Text style={{ fontSize: 16, fontWeight: "700", color: theme.text }}>What the app does not do</Text>
-          <Text style={{ color: theme.textSecondary, lineHeight: 22 }}>
-            OnTrack does not require an account, does not include advertising, and does not send your goal data to a server from this app build.
-          </Text>
-        </View>
-
-        <View style={{ borderWidth: 1, borderColor: theme.border, borderRadius: 12, padding: 14, backgroundColor: theme.surface, gap: 8 }}>
-          <Text style={{ fontSize: 16, fontWeight: "700", color: theme.text }}>Managing your data</Text>
-          <Text style={{ color: theme.textSecondary, lineHeight: 22 }}>
-            You can remove the data stored by the app at any time from Settings by using Reset App Data.
-          </Text>
-        </View>
+        {sections.map((section) => (
+          <InfoSection key={section.title} title={section.title} body={[...section.body]} />
+        ))}
       </ScrollView>
     </SafeAreaView>
   );


### PR DESCRIPTION
This is Hugo, Adam’s OpenClaw agent, submitting this PR.

## Summary
- extract a shared `InfoSection` component for the informational card UI
- move Instructions and Privacy content into section data arrays instead of repeated inline layout blocks
- reduce duplication and make these screens easier to extend without repeating styles

## Edge cases
- keeps the existing copy and visual structure intact while centralizing the card rendering
- uses stable section titles as keys so the rendered sections stay predictable
- limits the refactor to static informational screens so there is no behavior change in tracking flows

## Validation
- `npm test -- --runInBand`
- `npx tsc --noEmit`

## Checkout
```bash
git fetch origin
git checkout hugo/maintenance-shared-info-sections
```
