### PR TITLE
Refactor shared labeled text field

### DIFF
--- a/components/LabeledTextField.tsx
+++ b/components/LabeledTextField.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+import { Text, TextInput } from "react-native";
+import { useTheme } from "../contexts/ThemeContext";
+
+type LabeledTextFieldProps = {
+  label: string;
+  placeholder: string;
+  value: string;
+  onChangeText: (value: string) => void;
+};
+
+export default function LabeledTextField({
+  label,
+  placeholder,
+  value,
+  onChangeText,
+}: LabeledTextFieldProps) {
+  const { theme } = useTheme();
+
+  return (
+    <>
+      <Text style={{ fontWeight: "700", fontSize: 16, color: theme.text }}>{label}</Text>
+      <TextInput
+        placeholder={placeholder}
+        value={value}
+        onChangeText={onChangeText}
+        style={{
+          borderWidth: 1,
+          borderColor: theme.border,
+          borderRadius: 8,
+          padding: 10,
+          backgroundColor: theme.surface,
+          color: theme.text,
+        }}
+        placeholderTextColor={theme.textSecondary}
+      />
+    </>
+  );
+}

--- a/components/NewGoalScreen.tsx
+++ b/components/NewGoalScreen.tsx
@@ -1,10 +1,11 @@
 import React from "react";
 import { NativeStackScreenProps } from "@react-navigation/native-stack";
-import { Text, View, Pressable, TextInput } from "react-native";
+import { Text, View, Pressable } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useStore } from "../store";
 import { useTheme } from "../contexts/ThemeContext";
 import { haptics } from "../utils/haptics";
+import LabeledTextField from "./LabeledTextField";
 
 type RootStackParamList = {
   Home: undefined;
@@ -24,38 +25,18 @@ export default function NewGoalScreen({ navigation }: NewGoalProps) {
   return (
     <SafeAreaView style={{ flex: 1, backgroundColor: theme.background }} edges={['bottom', 'left', 'right']}>
       <View style={{ padding: 16, gap: 12 }}>
-        {/* Label + Input for Goal Title */}
-        <Text style={{ fontWeight: "700", fontSize: 16, color: theme.text }}>Goal Title</Text>
-        <TextInput
+        <LabeledTextField
+          label="Goal Title"
           placeholder="e.g., Fitness"
           value={title}
           onChangeText={setTitle}
-          style={{
-            borderWidth: 1,
-            borderColor: theme.border,
-            borderRadius: 8,
-            padding: 10,
-            backgroundColor: theme.surface,
-            color: theme.text
-          }}
-          placeholderTextColor={theme.textSecondary}
         />
 
-        {/* Label + Input for Target */}
-        <Text style={{ fontWeight: "700", fontSize: 16, color: theme.text }}>Target (optional)</Text>
-        <TextInput
+        <LabeledTextField
+          label="Target (optional)"
           placeholder="e.g., 200 lbs, 10% BF"
           value={target}
           onChangeText={setTarget}
-          style={{
-            borderWidth: 1,
-            borderColor: theme.border,
-            borderRadius: 8,
-            padding: 10,
-            backgroundColor: theme.surface,
-            color: theme.text
-          }}
-          placeholderTextColor={theme.textSecondary}
         />
 
         <Pressable


### PR DESCRIPTION
This is Hugo, Adam’s OpenClaw agent, submitting this PR.

## Summary
- extract a shared `LabeledTextField` component for simple label + input pairs
- replace the duplicated goal title and target field markup in `NewGoalScreen`
- keep the screen behavior unchanged while reducing repeated form styling

## Edge cases
- preserves the existing placeholder text and field values for both inputs
- keeps theme-aware input styling in one place instead of duplicating it inline
- limits the refactor to the new goal form so no goal-creation behavior changes

## Validation
- `npm test -- --runInBand`
- `npx tsc --noEmit`

## Checkout
```bash
git fetch origin
git checkout hugo/maintenance-extract-labeled-text-field
```
