### PR TITLE
Extract shared navigation route types

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -10,15 +10,7 @@ import NewGoalScreen from "./components/NewGoalScreen";
 import OverviewScreen from "./components/OverviewScreen";
 import PrivacyScreen from "./components/PrivacyScreen";
 import InstructionsScreen from "./components/InstructionsScreen";
-
-type RootStackParamList = {
-  Home: undefined;
-  Goal: { goalId: string };
-  NewGoal: undefined;
-  Consistency: { goalId: string };
-  Privacy: undefined;
-  Instructions: undefined;
-};
+import type { RootStackParamList } from "./navigation/types";
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
 

--- a/components/GoalScreen.tsx
+++ b/components/GoalScreen.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { NativeStackScreenProps } from "@react-navigation/native-stack";
 import { Text, View, Pressable, TextInput, ScrollView, Modal, Alert } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { Ionicons } from "@expo/vector-icons";
@@ -8,15 +7,9 @@ import { useTheme } from "../contexts/ThemeContext";
 import { format, startOfWeek, endOfWeek, isWithinInterval, isToday } from "date-fns";
 import { Frequency, CustomFrequency } from "../types";
 import { haptics } from "../utils/haptics";
+import type { RootStackScreenProps } from "../navigation/types";
 
-type RootStackParamList = {
-  Home: undefined;
-  Goal: { goalId: string };
-  NewGoal: undefined;
-  Consistency: { goalId: string };
-};
-
-type GoalProps = NativeStackScreenProps<RootStackParamList, "Goal">;
+type GoalProps = RootStackScreenProps<"Goal">;
 
 export default function GoalScreen({ navigation, route }: GoalProps) {
   const MAX_WEEKLY_CUSTOM_TARGET = 7;

--- a/components/HomeScreen.tsx
+++ b/components/HomeScreen.tsx
@@ -1,5 +1,4 @@
 import React, { useState, useLayoutEffect } from "react";
-import { NativeStackScreenProps } from "@react-navigation/native-stack";
 import { Text, View, Pressable, ScrollView, Alert, Switch, Modal } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { Ionicons } from '@expo/vector-icons';
@@ -9,17 +8,9 @@ import RadarChart from "./RadarChart";
 import DateContextCard from "./DateContextCard";
 import CalendarModal from "./CalendarModal";
 import { haptics } from "../utils/haptics";
+import type { RootStackScreenProps } from "../navigation/types";
 
-type RootStackParamList = {
-  Home: undefined;
-  Goal: { goalId: string };
-  NewGoal: undefined;
-  Consistency: { goalId: string };
-  Privacy: undefined;
-  Instructions: undefined;
-};
-
-type HomeProps = NativeStackScreenProps<RootStackParamList, "Home">;
+type HomeProps = RootStackScreenProps<"Home">;
 
 export default function HomeScreen({ navigation }: HomeProps) {
   const goals = useStore((s) => s.goals);

--- a/components/NewGoalScreen.tsx
+++ b/components/NewGoalScreen.tsx
@@ -1,19 +1,12 @@
 import React from "react";
-import { NativeStackScreenProps } from "@react-navigation/native-stack";
 import { Text, View, Pressable, TextInput } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useStore } from "../store";
 import { useTheme } from "../contexts/ThemeContext";
 import { haptics } from "../utils/haptics";
+import type { RootStackScreenProps } from "../navigation/types";
 
-type RootStackParamList = {
-  Home: undefined;
-  Goal: { goalId: string };
-  NewGoal: undefined;
-  Consistency: { goalId: string };
-};
-
-type NewGoalProps = NativeStackScreenProps<RootStackParamList, "NewGoal">;
+type NewGoalProps = RootStackScreenProps<"NewGoal">;
 
 export default function NewGoalScreen({ navigation }: NewGoalProps) {
   const addGoal = useStore((s) => s.addGoal);

--- a/components/OverviewScreen.tsx
+++ b/components/OverviewScreen.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { NativeStackScreenProps } from "@react-navigation/native-stack";
 import { Text, View, ScrollView } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { Ionicons } from "@expo/vector-icons";
@@ -8,15 +7,9 @@ import { useStore, getCustomFrequencyProgress, getGoalStreak } from "../store";
 import { useTheme } from "../contexts/ThemeContext";
 import Heatmap from "./Heatmap";
 import { format } from "date-fns";
+import type { RootStackScreenProps } from "../navigation/types";
 
-type RootStackParamList = {
-  Home: undefined;
-  Goal: { goalId: string };
-  NewGoal: undefined;
-  Consistency: { goalId: string };
-};
-
-type OverviewProps = NativeStackScreenProps<RootStackParamList, "Consistency">;
+type OverviewProps = RootStackScreenProps<"Consistency">;
 
 export default function OverviewScreen({ navigation, route }: OverviewProps) {
   const streakBadgeSize = 24;

--- a/navigation/types.ts
+++ b/navigation/types.ts
@@ -1,0 +1,13 @@
+import type { NativeStackScreenProps } from "@react-navigation/native-stack";
+
+export type RootStackParamList = {
+  Home: undefined;
+  Goal: { goalId: string };
+  NewGoal: undefined;
+  Consistency: { goalId: string };
+  Privacy: undefined;
+  Instructions: undefined;
+};
+
+export type RootStackScreenProps<Screen extends keyof RootStackParamList> =
+  NativeStackScreenProps<RootStackParamList, Screen>;


### PR DESCRIPTION
This is Echo, Kyle's OpenClaw agent, submitting this PR.

## Summary
- move the root stack param list into a shared `navigation/types.ts` module
- update `App.tsx` and typed screen components to import the shared navigation types
- replace repeated inline screen prop declarations with a shared `RootStackScreenProps` helper

## Edge cases and non-goals
- this is a type-only refactor, so runtime navigation behavior is intentionally unchanged
- only the root stack types were centralized here, no screen flow or route names were changed

## Validation
- `npx tsc --noEmit`

## Checkout
- `git fetch origin && git checkout echo/issue-71-shared-navigation-types`

Closes #71
