### PR TITLE
Let users edit and clear goal targets

### DIFF
--- a/components/GoalScreen.tsx
+++ b/components/GoalScreen.tsx
@@ -38,29 +38,35 @@ export default function GoalScreen({ navigation, route }: GoalProps) {
   const [customFrequency, setCustomFrequency] = React.useState<CustomFrequency>({ type: "weekly", target: 3 });
   const [isEditing, setIsEditing] = React.useState(false);
   const [editingTaskId, setEditingTaskId] = React.useState<string | null>(null);
-  const [isEditingGoalTitle, setIsEditingGoalTitle] = React.useState(false);
+  const [isEditingGoalDetails, setIsEditingGoalDetails] = React.useState(false);
   const [goalTitleDraft, setGoalTitleDraft] = React.useState(goal.title);
+  const [goalTargetDraft, setGoalTargetDraft] = React.useState(goal.target ?? "");
   const [isReorderingTasks, setIsReorderingTasks] = React.useState(false);
 
   if (!goal) return <Text>Not found</Text>;
 
   React.useEffect(() => {
-    if (!isEditingGoalTitle) {
+    if (!isEditingGoalDetails) {
       setGoalTitleDraft(goal.title);
+      setGoalTargetDraft(goal.target ?? "");
     }
-  }, [goal.title, isEditingGoalTitle]);
+  }, [goal.title, goal.target, isEditingGoalDetails]);
 
-  const saveGoalTitle = () => {
+  const saveGoalDetails = () => {
     const trimmedTitle = goalTitleDraft.trim();
+    const trimmedTarget = goalTargetDraft.trim();
 
     if (!trimmedTitle) {
       void haptics.error();
       return;
     }
 
-    updateGoal(goalId, { title: trimmedTitle });
+    updateGoal(goalId, {
+      title: trimmedTitle,
+      target: trimmedTarget ? trimmedTarget : null,
+    });
     void haptics.success();
-    setIsEditingGoalTitle(false);
+    setIsEditingGoalDetails(false);
   };
 
   const isCompletedToday = (dates: Date[], referenceDate: Date) =>
@@ -225,7 +231,7 @@ export default function GoalScreen({ navigation, route }: GoalProps) {
         showsVerticalScrollIndicator={false}
       >
         <View style={{ flexDirection: "row", alignItems: "center", gap: 8 }}>
-          {isEditingGoalTitle ? (
+          {isEditingGoalDetails ? (
             <>
               <TextInput
                 value={goalTitleDraft}
@@ -246,10 +252,10 @@ export default function GoalScreen({ navigation, route }: GoalProps) {
                 placeholderTextColor={theme.textSecondary}
                 autoFocus
                 returnKeyType="done"
-                onSubmitEditing={saveGoalTitle}
+                onSubmitEditing={saveGoalDetails}
               />
               <Pressable
-                onPress={saveGoalTitle}
+                onPress={saveGoalDetails}
                 hitSlop={8}
                 style={{ padding: 6 }}
               >
@@ -259,7 +265,8 @@ export default function GoalScreen({ navigation, route }: GoalProps) {
                 onPress={() => {
                   void haptics.tap();
                   setGoalTitleDraft(goal.title);
-                  setIsEditingGoalTitle(false);
+                  setGoalTargetDraft(goal.target ?? "");
+                  setIsEditingGoalDetails(false);
                 }}
                 hitSlop={8}
                 style={{ padding: 6 }}
@@ -274,7 +281,8 @@ export default function GoalScreen({ navigation, route }: GoalProps) {
                 onPress={() => {
                   void haptics.tap();
                   setGoalTitleDraft(goal.title);
-                  setIsEditingGoalTitle(true);
+                  setGoalTargetDraft(goal.target ?? "");
+                  setIsEditingGoalDetails(true);
                 }}
                 hitSlop={8}
                 style={{
@@ -293,7 +301,33 @@ export default function GoalScreen({ navigation, route }: GoalProps) {
             </>
           )}
         </View>
-        {goal.target && <Text style={{ color: theme.textSecondary }}>Target: {goal.target}</Text>}
+        {isEditingGoalDetails ? (
+          <View style={{ gap: 8 }}>
+            <TextInput
+              value={goalTargetDraft}
+              onChangeText={setGoalTargetDraft}
+              style={{
+                fontSize: 15,
+                color: theme.text,
+                borderWidth: 1,
+                borderColor: theme.border,
+                borderRadius: 10,
+                paddingHorizontal: 12,
+                paddingVertical: 10,
+                backgroundColor: theme.surface,
+              }}
+              placeholder="Optional target"
+              placeholderTextColor={theme.textSecondary}
+              returnKeyType="done"
+              onSubmitEditing={saveGoalDetails}
+            />
+            <Text style={{ color: theme.textSecondary, fontSize: 12 }}>
+              Leave blank to clear the target.
+            </Text>
+          </View>
+        ) : goal.target ? (
+          <Text style={{ color: theme.textSecondary }}>Target: {goal.target}</Text>
+        ) : null}
         <View style={{ flexDirection: "row", gap: 8, flexWrap: "wrap" }}>
           <Pressable
             onPress={() => {

--- a/store.test.ts
+++ b/store.test.ts
@@ -1,4 +1,4 @@
-import { getCustomFrequencyProgress, getSampleGoals, isOnceTaskCompletedOnDate } from './store';
+import { getCustomFrequencyProgress, getSampleGoals, isOnceTaskCompletedOnDate, useStore } from './store';
 import { Task } from './types';
 
 describe('getCustomFrequencyProgress', () => {
@@ -81,5 +81,62 @@ describe('isOnceTaskCompletedOnDate', () => {
     };
 
     expect(isOnceTaskCompletedOnDate(task, new Date('2026-04-21T12:00:00.000Z'))).toBe(false);
+  });
+});
+
+describe('updateGoal', () => {
+  const originalState = useStore.getState();
+
+  afterEach(() => {
+    useStore.setState(originalState, true);
+  });
+
+  it('updates a goal target without affecting its tasks', () => {
+    useStore.setState({
+      ...originalState,
+      goals: [
+        {
+          id: 'goal-1',
+          title: 'Fitness',
+          target: 'Run a 5k',
+          createdAt: Date.now(),
+          tasks: [
+            {
+              id: 'task-1',
+              title: 'Run',
+              frequency: 'daily',
+              completions: [new Date('2026-04-20T12:00:00.000Z')],
+            },
+          ],
+        },
+      ],
+    });
+
+    useStore.getState().updateGoal('goal-1', { target: 'Run a 10k' });
+
+    const updatedGoal = useStore.getState().goals[0];
+    expect(updatedGoal.target).toBe('Run a 10k');
+    expect(updatedGoal.tasks).toHaveLength(1);
+    expect(updatedGoal.tasks[0].title).toBe('Run');
+    expect(updatedGoal.tasks[0].completions).toHaveLength(1);
+  });
+
+  it('clears a goal target when null is provided', () => {
+    useStore.setState({
+      ...originalState,
+      goals: [
+        {
+          id: 'goal-2',
+          title: 'Nutrition',
+          target: '2000 calories',
+          createdAt: Date.now(),
+          tasks: [],
+        },
+      ],
+    });
+
+    useStore.getState().updateGoal('goal-2', { target: null });
+
+    expect(useStore.getState().goals[0].target).toBeUndefined();
   });
 });

--- a/store.ts
+++ b/store.ts
@@ -543,7 +543,7 @@ interface State {
     addGoal: (title: string, target?: string) => void;
     reorderGoals: (goalIdsInOrder: string[]) => void;
     setSelectedDate: (date: Date) => void;
-    updateGoal: (goalId: string, updates: { title?: string; target?: string }) => void;
+    updateGoal: (goalId: string, updates: { title?: string; target?: string | null }) => void;
     addTask: (goalId: string, title: string, frequency: Frequency, customFrequency?: CustomFrequency) => void;
     updateTask: (goalId: string, taskId: string, updates: { title?: string; frequency?: Frequency; customFrequency?: CustomFrequency | undefined }) => void;
     reorderTasks: (goalId: string, taskIdsInOrder: string[]) => void;
@@ -601,7 +601,11 @@ export const useStore = create<State>()(
                             ? {
                                 ...g,
                                 title: updates.title ?? g.title,
-                                target: updates.target !== undefined ? updates.target : g.target,
+                                target: updates.target === null
+                                    ? undefined
+                                    : updates.target !== undefined
+                                      ? updates.target
+                                      : g.target,
                             }
                             : g
                     ),


### PR DESCRIPTION
This is Hugo, Adam’s OpenClaw agent, submitting this PR.

## Summary
- let users edit a goal's title and optional target together from the existing goal screen
- support adding a missing target, updating an existing target, and clearing the target by saving an empty value
- add regression coverage for updating and clearing goal targets without affecting task data

## Edge cases / non-goals
- empty or whitespace-only target input is treated as clearing the target
- goal title still cannot be saved empty
- this keeps the current inline goal editing approach instead of introducing a new modal or redesign

## Validation
- `npm test -- --runInBand`
- `npx tsc --noEmit`

## Checkout
```bash
git fetch origin
git checkout hugo/issue-81-edit-goal-target
```

Closes #81
