### PR TITLE
Add visible validation states for blank goal and task titles

### DIFF
--- a/components/GoalScreen.tsx
+++ b/components/GoalScreen.tsx
@@ -41,7 +41,9 @@ export default function GoalScreen({ navigation, route }: GoalProps) {
   const [isEditingGoalDetails, setIsEditingGoalDetails] = React.useState(false);
   const [goalTitleDraft, setGoalTitleDraft] = React.useState(goal.title);
   const [goalTargetDraft, setGoalTargetDraft] = React.useState(goal.target ?? "");
+  const [goalTitleError, setGoalTitleError] = React.useState("");
   const [isReorderingTasks, setIsReorderingTasks] = React.useState(false);
+  const [taskTitleError, setTaskTitleError] = React.useState("");
 
   if (!goal) return <Text>Not found</Text>;
 
@@ -49,6 +51,7 @@ export default function GoalScreen({ navigation, route }: GoalProps) {
     if (!isEditingGoalDetails) {
       setGoalTitleDraft(goal.title);
       setGoalTargetDraft(goal.target ?? "");
+      setGoalTitleError("");
     }
   }, [goal.title, goal.target, isEditingGoalDetails]);
 
@@ -57,6 +60,7 @@ export default function GoalScreen({ navigation, route }: GoalProps) {
     const trimmedTarget = goalTargetDraft.trim();
 
     if (!trimmedTitle) {
+      setGoalTitleError("Enter a goal title.");
       void haptics.error();
       return;
     }
@@ -66,6 +70,7 @@ export default function GoalScreen({ navigation, route }: GoalProps) {
       target: trimmedTarget ? trimmedTarget : null,
     });
     void haptics.success();
+    setGoalTitleError("");
     setIsEditingGoalDetails(false);
   };
 
@@ -92,6 +97,7 @@ export default function GoalScreen({ navigation, route }: GoalProps) {
 
   const resetTaskEditor = () => {
     setTaskTitle("");
+    setTaskTitleError("");
     setFrequency("daily");
     setCustomFrequency({ type: "weekly", target: 3 });
     setEditingTaskId(null);
@@ -118,6 +124,7 @@ export default function GoalScreen({ navigation, route }: GoalProps) {
     const trimmedTitle = taskTitle.trim();
 
     if (!trimmedTitle) {
+      setTaskTitleError("Enter a task title.");
       void haptics.error();
       return;
     }
@@ -235,14 +242,19 @@ export default function GoalScreen({ navigation, route }: GoalProps) {
             <>
               <TextInput
                 value={goalTitleDraft}
-                onChangeText={setGoalTitleDraft}
+                onChangeText={(text) => {
+                  setGoalTitleDraft(text);
+                  if (text.trim()) {
+                    setGoalTitleError("");
+                  }
+                }}
                 style={{
                   flex: 1,
                   fontSize: 22,
                   fontWeight: "800",
                   color: theme.text,
                   borderWidth: 1,
-                  borderColor: theme.primary,
+                  borderColor: goalTitleError ? theme.danger : theme.primary,
                   borderRadius: 10,
                   paddingHorizontal: 12,
                   paddingVertical: 8,
@@ -258,6 +270,7 @@ export default function GoalScreen({ navigation, route }: GoalProps) {
                 onPress={saveGoalDetails}
                 hitSlop={8}
                 style={{ padding: 6 }}
+                accessibilityLabel="Save goal details"
               >
                 <Ionicons name="checkmark-outline" size={20} color={theme.primary} />
               </Pressable>
@@ -266,10 +279,12 @@ export default function GoalScreen({ navigation, route }: GoalProps) {
                   void haptics.tap();
                   setGoalTitleDraft(goal.title);
                   setGoalTargetDraft(goal.target ?? "");
+                  setGoalTitleError("");
                   setIsEditingGoalDetails(false);
                 }}
                 hitSlop={8}
                 style={{ padding: 6 }}
+                accessibilityLabel="Cancel goal editing"
               >
                 <Ionicons name="close-outline" size={20} color={theme.textSecondary} />
               </Pressable>
@@ -295,12 +310,16 @@ export default function GoalScreen({ navigation, route }: GoalProps) {
                   borderWidth: 1,
                   borderColor: theme.border,
                 }}
+                accessibilityLabel="Edit goal details"
               >
                 <Ionicons name="create-outline" size={16} color={theme.textSecondary} />
               </Pressable>
             </>
           )}
         </View>
+        {isEditingGoalDetails && goalTitleError ? (
+          <Text style={{ color: theme.danger, fontSize: 13, marginTop: -2 }}>{goalTitleError}</Text>
+        ) : null}
         {isEditingGoalDetails ? (
           <View style={{ gap: 8 }}>
             <TextInput
@@ -785,11 +804,26 @@ export default function GoalScreen({ navigation, route }: GoalProps) {
               <TextInput
                 placeholder="e.g., Take creatine"
                 value={taskTitle}
-                onChangeText={setTaskTitle}
-                style={{ borderWidth: 1, borderColor: theme.border, borderRadius: 8, padding: 10, backgroundColor: theme.background, color: theme.text }}
+                onChangeText={(text) => {
+                  setTaskTitle(text);
+                  if (text.trim()) {
+                    setTaskTitleError("");
+                  }
+                }}
+                style={{
+                  borderWidth: 1,
+                  borderColor: taskTitleError ? theme.danger : theme.border,
+                  borderRadius: 8,
+                  padding: 10,
+                  backgroundColor: theme.background,
+                  color: theme.text,
+                }}
                 placeholderTextColor={theme.textSecondary}
                 autoFocus={true}
               />
+              {taskTitleError ? (
+                <Text style={{ color: theme.danger, fontSize: 13, marginTop: -2 }}>{taskTitleError}</Text>
+              ) : null}
               <View style={{ flexDirection: "row", gap: 8, flexWrap: "wrap" }}>
                 {(["once", "daily", "weekly", "custom"] as Frequency[]).map((f) => (
                   <Pressable
@@ -918,6 +952,7 @@ export default function GoalScreen({ navigation, route }: GoalProps) {
                 <Pressable
                   onPress={submitTaskEditor}
                   style={{ flex: 1, backgroundColor: theme.primary, padding: 10, borderRadius: 8 }}
+                  accessibilityLabel={editingTaskId ? "Save task" : "Add task"}
                 >
                   <Text style={{ color: "white", textAlign: "center", fontWeight: "700" }}>{editingTaskId ? "Save" : "Add"}</Text>
                 </Pressable>

--- a/components/NewGoalScreen.tsx
+++ b/components/NewGoalScreen.tsx
@@ -20,16 +20,40 @@ export default function NewGoalScreen({ navigation }: NewGoalProps) {
   const addGoal = useStore((s) => s.addGoal);
   const [title, setTitle] = React.useState("");
   const [target, setTarget] = React.useState("");
+  const [titleError, setTitleError] = React.useState("");
   const { theme } = useTheme();
 
+  const handleTitleChange = (nextTitle: string) => {
+    setTitle(nextTitle);
+
+    if (nextTitle.trim()) {
+      setTitleError("");
+    }
+  };
+
+  const handleCreateGoal = () => {
+    if (title.trim()) {
+      void haptics.success();
+      addGoal(title.trim(), target.trim() || undefined);
+      navigation.goBack();
+      return;
+    }
+
+    setTitleError("Enter a goal title.");
+    void haptics.error();
+  };
+
   return (
-    <SafeAreaView style={{ flex: 1, backgroundColor: theme.background }} edges={['bottom', 'left', 'right']}>
+    <SafeAreaView style={{ flex: 1, backgroundColor: theme.background }} edges={["bottom", "left", "right"]}>
       <View style={{ padding: 16, gap: 12 }}>
         <LabeledTextField
           label="Goal Title"
           placeholder="e.g., Fitness"
           value={title}
-          onChangeText={setTitle}
+          onChangeText={handleTitleChange}
+          errorText={titleError || undefined}
+          returnKeyType="done"
+          onSubmitEditing={handleCreateGoal}
         />
 
         <LabeledTextField
@@ -40,16 +64,7 @@ export default function NewGoalScreen({ navigation }: NewGoalProps) {
         />
 
         <Pressable
-          onPress={() => {
-            if (title.trim()) {
-              void haptics.success();
-              addGoal(title.trim(), target.trim() || undefined);
-              navigation.goBack();
-              return;
-            }
-
-            void haptics.error();
-          }}
+          onPress={handleCreateGoal}
           style={{ backgroundColor: theme.primary, padding: 12, borderRadius: 10 }}
         >
           <Text

--- a/tests/validation-ui.test.tsx
+++ b/tests/validation-ui.test.tsx
@@ -1,0 +1,109 @@
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react-native';
+import NewGoalScreen from '../components/NewGoalScreen';
+import GoalScreen from '../components/GoalScreen';
+import { ThemeProvider } from '../contexts/ThemeContext';
+import { useStore } from '../store';
+
+jest.mock('@expo/vector-icons', () => {
+  const React = require('react');
+  const { Text } = require('react-native');
+
+  return {
+    Ionicons: ({ name }: { name: string }) => React.createElement(Text, null, name),
+  };
+});
+
+jest.mock('expo-haptics', () => ({
+  selectionAsync: jest.fn(),
+  impactAsync: jest.fn(),
+  notificationAsync: jest.fn(),
+  ImpactFeedbackStyle: { Light: 'Light', Heavy: 'Heavy' },
+  NotificationFeedbackType: { Success: 'Success', Warning: 'Warning', Error: 'Error' },
+}));
+
+jest.mock('react-native-draggable-flatlist', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+
+  const Mock = ({ children }: { children?: React.ReactNode }) => React.createElement(View, null, children);
+  return {
+    __esModule: true,
+    default: Mock,
+    ScaleDecorator: ({ children }: { children: React.ReactNode }) => React.createElement(React.Fragment, null, children),
+  };
+});
+
+const renderWithTheme = (ui: React.ReactElement) => render(<ThemeProvider>{ui}</ThemeProvider>);
+
+describe('visible validation states', () => {
+  afterEach(() => {
+    useStore.setState({
+      goals: [],
+      selectedDate: new Date('2026-05-04T12:00:00.000Z'),
+      account: null,
+    });
+  });
+
+  it('shows a visible error when creating a blank goal', () => {
+    const navigation = { goBack: jest.fn() } as any;
+
+    const screen = renderWithTheme(<NewGoalScreen navigation={navigation} route={{} as any} />);
+
+    fireEvent.press(screen.getByText('Create Goal'));
+
+    expect(screen.getByText('Enter a goal title.')).toBeTruthy();
+    expect(navigation.goBack).not.toHaveBeenCalled();
+  });
+
+  it('shows a visible error when saving a blank goal title edit', () => {
+    useStore.setState({
+      goals: [
+        {
+          id: 'goal-1',
+          title: 'Fitness',
+          target: 'Run a 5k',
+          createdAt: Date.now(),
+          tasks: [],
+        },
+      ],
+      selectedDate: new Date('2026-05-04T12:00:00.000Z'),
+      account: null,
+    });
+
+    const screen = renderWithTheme(
+      <GoalScreen navigation={{ navigate: jest.fn() } as any} route={{ params: { goalId: 'goal-1' } } as any} />
+    );
+
+    fireEvent.press(screen.getByLabelText('Edit goal details'));
+    fireEvent.changeText(screen.getByDisplayValue('Fitness'), '   ');
+    fireEvent.press(screen.getByLabelText('Save goal details'));
+
+    expect(screen.getByText('Enter a goal title.')).toBeTruthy();
+  });
+
+  it('shows a visible error when adding a blank task title', () => {
+    useStore.setState({
+      goals: [
+        {
+          id: 'goal-1',
+          title: 'Fitness',
+          target: 'Run a 5k',
+          createdAt: Date.now(),
+          tasks: [],
+        },
+      ],
+      selectedDate: new Date('2026-05-04T12:00:00.000Z'),
+      account: null,
+    });
+
+    const screen = renderWithTheme(
+      <GoalScreen navigation={{ navigate: jest.fn() } as any} route={{ params: { goalId: 'goal-1' } } as any} />
+    );
+
+    fireEvent.press(screen.getByText('+ New Task'));
+    fireEvent.press(screen.getByLabelText('Add task'));
+
+    expect(screen.getByText('Enter a task title.')).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary
- add visible validation feedback for blank goal creation, goal rename, and task add/edit flows
- clear validation errors as soon as the user types a non-blank title
- add regression tests for the new visible validation states


## Testing
- npm test -- --runInBand
- npx tsc --noEmit

Closes #98