### PR TITLE
feature: score radar chart current mode against the current week for all frequency types

### DIFF
--- a/components/RadarChart.tsx
+++ b/components/RadarChart.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import { View, Text } from "react-native";
 import Svg, { Polygon, Line, Circle, Text as SvgText } from "react-native-svg";
-import { Goal } from "../types";
-import { endOfDay, isAfter, isSameDay, isWithinInterval, startOfWeek, endOfWeek, differenceInCalendarDays } from "date-fns";
+import { Goal, Task } from "../types";
+import { endOfDay, isAfter, isWithinInterval, startOfWeek, endOfWeek, differenceInCalendarDays } from "date-fns";
 import { useTheme } from "../contexts/ThemeContext";
 import { getCustomFrequencyProgress } from "../store";
 
@@ -16,6 +16,29 @@ interface RadarChartProps {
 }
 
 const CHART_TITLE = "Goal Radar";
+
+export const getCurrentModeTaskScore = (
+  task: Task,
+  completionsThroughReferenceDate: Date[],
+  normalizedReferenceDate: Date
+): number => {
+  const weekStart = startOfWeek(normalizedReferenceDate, { weekStartsOn: 0 });
+  const weekEnd = endOfWeek(normalizedReferenceDate, { weekStartsOn: 0 });
+  const completionsThisWeek = completionsThroughReferenceDate.filter((completionDate) =>
+    isWithinInterval(completionDate, { start: weekStart, end: weekEnd })
+  ).length;
+
+  if (task.frequency === "daily") {
+    return Math.min(1, completionsThisWeek / 7);
+  }
+
+  if (task.frequency === "weekly") {
+    return Math.min(1, completionsThisWeek);
+  }
+
+  const progress = getCustomFrequencyProgress(task, normalizedReferenceDate);
+  return progress.target > 0 ? Math.min(1, progress.completed / progress.target) : 0;
+};
 
 const getDailyTrendScore = (completionDates: Date[], startDate: Date, referenceDate: Date) => {
   const days = Math.max(1, differenceInCalendarDays(referenceDate, startDate) + 1);
@@ -123,20 +146,7 @@ export default function RadarChart({ goals, size = 200, referenceDate = new Date
         }
 
         if (mode === "current") {
-          if (task.frequency === "daily") {
-            return completionsThroughReferenceDate.some((completionDate) => isSameDay(completionDate, normalizedReferenceDate)) ? 1 : 0;
-          }
-
-          if (task.frequency === "weekly") {
-            const weekStart = startOfWeek(normalizedReferenceDate, { weekStartsOn: 0 });
-            const weekEnd = endOfWeek(normalizedReferenceDate, { weekStartsOn: 0 });
-            return completionsThroughReferenceDate.some((completionDate) =>
-              isWithinInterval(completionDate, { start: weekStart, end: weekEnd })
-            ) ? 1 : 0;
-          }
-
-          const progress = getCustomFrequencyProgress(task, normalizedReferenceDate);
-          return progress.target > 0 ? Math.min(1, progress.completed / progress.target) : 0;
+          return getCurrentModeTaskScore(task, completionsThroughReferenceDate, normalizedReferenceDate);
         }
 
         if (task.frequency === "daily") {

--- a/tests/radarChart.test.ts
+++ b/tests/radarChart.test.ts
@@ -1,0 +1,96 @@
+import { endOfDay } from "date-fns";
+import { getCurrentModeTaskScore } from "../components/RadarChart";
+import { Task } from "../types";
+
+// Reference week: Sun 2026-04-19 – Sat 2026-04-25
+// Reference date: Wed 2026-04-22 (mid-week)
+const REFERENCE_DATE = endOfDay(new Date("2026-04-22T12:00:00.000Z"));
+
+const inWeek = (isoString: string) => new Date(isoString);
+
+const makeTask = (frequency: Task["frequency"], customFrequency?: Task["customFrequency"]): Task => ({
+  id: "t1",
+  title: "Task",
+  frequency,
+  customFrequency,
+  completions: [],
+});
+
+describe("getCurrentModeTaskScore — daily frequency", () => {
+  it("scores 1/7 after one completion this week", () => {
+    const completions = [inWeek("2026-04-20T12:00:00.000Z")];
+    const score = getCurrentModeTaskScore(makeTask("daily"), completions, REFERENCE_DATE);
+    expect(score).toBeCloseTo(1 / 7);
+  });
+
+  it("scores 4/7 after four completions this week", () => {
+    const completions = [
+      inWeek("2026-04-19T12:00:00.000Z"),
+      inWeek("2026-04-20T12:00:00.000Z"),
+      inWeek("2026-04-21T12:00:00.000Z"),
+      inWeek("2026-04-22T12:00:00.000Z"),
+    ];
+    const score = getCurrentModeTaskScore(makeTask("daily"), completions, REFERENCE_DATE);
+    expect(score).toBeCloseTo(4 / 7);
+  });
+
+  it("scores 1.0 after seven completions this week", () => {
+    const completions = [
+      inWeek("2026-04-19T12:00:00.000Z"),
+      inWeek("2026-04-20T12:00:00.000Z"),
+      inWeek("2026-04-21T12:00:00.000Z"),
+      inWeek("2026-04-22T12:00:00.000Z"),
+      inWeek("2026-04-23T12:00:00.000Z"),
+      inWeek("2026-04-24T12:00:00.000Z"),
+      inWeek("2026-04-25T12:00:00.000Z"),
+    ];
+    const score = getCurrentModeTaskScore(makeTask("daily"), completions, REFERENCE_DATE);
+    expect(score).toBe(1);
+  });
+
+  it("scores 0 when completions exist only in a prior week", () => {
+    const completions = [inWeek("2026-04-18T12:00:00.000Z")]; // Saturday before the week
+    const score = getCurrentModeTaskScore(makeTask("daily"), completions, REFERENCE_DATE);
+    expect(score).toBe(0);
+  });
+});
+
+describe("getCurrentModeTaskScore — weekly frequency", () => {
+  it("scores 1.0 after one completion this week", () => {
+    const completions = [inWeek("2026-04-20T12:00:00.000Z")];
+    const score = getCurrentModeTaskScore(makeTask("weekly"), completions, REFERENCE_DATE);
+    expect(score).toBe(1);
+  });
+
+  it("scores 0 when completed only in a prior week", () => {
+    const completions = [inWeek("2026-04-12T12:00:00.000Z")]; // Previous week
+    const score = getCurrentModeTaskScore(makeTask("weekly"), completions, REFERENCE_DATE);
+    expect(score).toBe(0);
+  });
+});
+
+describe("getCurrentModeTaskScore — daily vs custom consistency", () => {
+  it("daily completed once equals custom 7x/week completed once", () => {
+    const completions = [inWeek("2026-04-20T12:00:00.000Z")];
+
+    const dailyScore = getCurrentModeTaskScore(makeTask("daily"), completions, REFERENCE_DATE);
+
+    // getCustomFrequencyProgress reads task.completions directly, so populate them on the task
+    const customTask: Task = { ...makeTask("custom", { type: "weekly", target: 7 }), completions };
+    const customScore = getCurrentModeTaskScore(customTask, completions, REFERENCE_DATE);
+
+    expect(dailyScore).toBeCloseTo(customScore);
+  });
+
+  it("custom 1x/week completed once scores 1.0, same as weekly", () => {
+    const completions = [inWeek("2026-04-20T12:00:00.000Z")];
+
+    const weeklyScore = getCurrentModeTaskScore(makeTask("weekly"), completions, REFERENCE_DATE);
+
+    const customTask: Task = { ...makeTask("custom", { type: "weekly", target: 1 }), completions };
+    const customScore = getCurrentModeTaskScore(customTask, completions, REFERENCE_DATE);
+
+    expect(customScore).toBe(1);
+    expect(weeklyScore).toBe(1);
+  });
+});


### PR DESCRIPTION
Daily tasks now contribute 1/7 per completion instead of snapping to 100% on first completion, making them consistent with custom frequency goals. Extracts getCurrentModeTaskScore as a testable function and adds unit tests covering daily, weekly, and custom frequency scoring.

Closes #104