### PR TITLE
Fix impossible once-task history after frequency edits

### DIFF
--- a/store.ts
+++ b/store.ts
@@ -36,6 +36,18 @@ const normalizeGoal = (goal: PersistedGoal): Goal => ({
   tasks: (goal.tasks ?? goal.subGoals ?? []).map(normalizeTask),
 });
 
+const normalizeCompletionsForFrequencyChange = (task: Task, nextFrequency: Frequency): Date[] => {
+  if (task.frequency === nextFrequency || nextFrequency !== "once" || task.completions.length <= 1) {
+    return task.completions;
+  }
+
+  const latestCompletion = task.completions.reduce((latest, completion) =>
+    normalizeDate(completion) > normalizeDate(latest) ? completion : latest
+  );
+
+  return [normalizeDate(latestCompletion)];
+};
+
 // Helper functions for custom frequency calculations
 export const getCustomFrequencyProgress = (task: Task, referenceDate: Date = new Date()) => {
   if (task.frequency !== "custom" || !task.customFrequency) {
@@ -653,6 +665,10 @@ export const useStore = create<State>()(
                                             customFrequency: (updates.frequency ?? task.frequency) === "custom"
                                                 ? (updates.customFrequency ?? task.customFrequency)
                                                 : undefined,
+                                            completions: normalizeCompletionsForFrequencyChange(
+                                                task,
+                                                updates.frequency ?? task.frequency
+                                            ),
                                         }
                                         : task
                                 ),

--- a/tests/store.test.ts
+++ b/tests/store.test.ts
@@ -180,3 +180,83 @@ describe('updateGoal', () => {
     expect(useStore.getState().goals[0].target).toBeUndefined();
   });
 });
+
+describe('updateTask', () => {
+  const originalState = useStore.getState();
+
+  afterEach(() => {
+    useStore.setState(originalState, true);
+  });
+
+  it('collapses recurring completion history to the latest day when changing a task to once', () => {
+    useStore.setState({
+      ...originalState,
+      goals: [
+        {
+          id: 'goal-1',
+          title: 'Fitness',
+          createdAt: Date.now(),
+          tasks: [
+            {
+              id: 'task-1',
+              title: 'Run',
+              frequency: 'daily',
+              completions: [
+                new Date('2026-04-20T18:00:00.000Z'),
+                new Date('2026-04-22T09:00:00.000Z'),
+                new Date('2026-04-21T12:00:00.000Z'),
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    useStore.getState().updateTask('goal-1', 'task-1', { frequency: 'once' });
+
+    const updatedTask = useStore.getState().goals[0].tasks[0];
+
+    expect(updatedTask.frequency).toBe('once');
+    expect(updatedTask.completions).toHaveLength(1);
+    expect(updatedTask.completions[0].toDateString()).toBe(
+      new Date('2026-04-22T12:00:00.000Z').toDateString()
+    );
+  });
+
+  it('keeps the normalized once completion when switching back to a recurring task', () => {
+    useStore.setState({
+      ...originalState,
+      goals: [
+        {
+          id: 'goal-2',
+          title: 'Admin',
+          createdAt: Date.now(),
+          tasks: [
+            {
+              id: 'task-2',
+              title: 'File paperwork',
+              frequency: 'daily',
+              completions: [
+                new Date('2026-04-20T12:00:00.000Z'),
+                new Date('2026-04-21T12:00:00.000Z'),
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    useStore.getState().updateTask('goal-2', 'task-2', { frequency: 'once' });
+    useStore.getState().updateTask('goal-2', 'task-2', { frequency: 'weekly' });
+    useStore.getState().toggleTaskCompletion('goal-2', 'task-2', new Date('2026-04-28T12:00:00.000Z'));
+
+    const updatedTask = useStore.getState().goals[0].tasks[0];
+
+    expect(updatedTask.frequency).toBe('weekly');
+    expect(updatedTask.completions).toHaveLength(2);
+    expect(updatedTask.completions.map((completion) => completion.toDateString())).toEqual([
+      new Date('2026-04-21T12:00:00.000Z').toDateString(),
+      new Date('2026-04-28T12:00:00.000Z').toDateString(),
+    ]);
+  });
+});


### PR DESCRIPTION
This is Echo, Kyle's OpenClaw agent, submitting this PR.

## Summary of changes
- normalize task completion history when `updateTask(...)` changes a task from a recurring frequency to `once`
- keep only the latest completed day so once-off tasks stay in a valid single-completion state
- add store regression tests for converting recurring tasks to `once` and then back to a recurring frequency

## Edge cases or non-goals
- if a recurring task has no completions or only one completion, its history is left unchanged
- this PR does not redesign once-task semantics or migrate older persisted data outside the existing edit flow
- when collapsing multiple recurring completions, the most recent completed day is preserved

## Validation run
- `npm test -- tests/store.test.ts --runInBand`
- `npx tsc --noEmit`

## Checkout command
- `git fetch origin`
- `git checkout echo/issue-99-edit-task-to-once`

Closes #99
