### PR TITLE
feat: add Supabase auth foundation

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -5,6 +5,7 @@ import { StatusBar } from "expo-status-bar";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
 import { SafeAreaProvider } from "react-native-safe-area-context";
 import AsyncStorage from "@react-native-async-storage/async-storage";
+import { Session } from "@supabase/supabase-js";
 import { ThemeProvider, useTheme } from "./contexts/ThemeContext";
 import HomeScreen from "./components/HomeScreen";
 import GoalScreen from "./components/GoalScreen";
@@ -13,10 +14,18 @@ import OverviewScreen from "./components/OverviewScreen";
 import PrivacyScreen from "./components/PrivacyScreen";
 import InstructionsScreen from "./components/InstructionsScreen";
 import IntroductionWizard from "./components/IntroductionWizard";
-import AccountSetupScreen from "./components/AccountSetupScreen";
+import AuthScreen from "./components/AuthScreen";
 import { ONBOARDING_STORAGE_KEY, shouldShowOnboarding } from "./onboarding";
-import { shouldPromptForAccountSetup } from "./account";
 import { useStore } from "./store";
+import {
+  AuthMode,
+  ensureProfileForUser,
+  getPersistedSession,
+  resendSignupVerification,
+  signInWithEmail,
+  signUpWithEmail,
+} from "./lib/auth";
+import { supabase } from "./lib/supabase";
 
 type RootStackParamList = {
   Home: undefined;
@@ -32,11 +41,17 @@ const Stack = createNativeStackNavigator<RootStackParamList>();
 function ThemedNavigation() {
   const { theme, isDark } = useTheme();
   const goals = useStore((s) => s.goals);
-  const account = useStore((s) => s.account);
   const seedDemoData = useStore((s) => s.seedDemoData);
-  const createAccount = useStore((s) => s.createAccount);
+  const setAccount = useStore((s) => s.setAccount);
   const [showIntroduction, setShowIntroduction] = React.useState(false);
   const [hasCheckedIntroduction, setHasCheckedIntroduction] = React.useState(false);
+  const [hasCheckedSession, setHasCheckedSession] = React.useState(false);
+  const [session, setSession] = React.useState<Session | null>(null);
+  const [authMode, setAuthMode] = React.useState<AuthMode>("sign-up");
+  const [authErrorMessage, setAuthErrorMessage] = React.useState<string | null>(null);
+  const [authInfoMessage, setAuthInfoMessage] = React.useState<string | null>(null);
+  const [pendingVerificationEmail, setPendingVerificationEmail] = React.useState<string | null>(null);
+  const [isSubmittingAuth, setIsSubmittingAuth] = React.useState(false);
 
   React.useEffect(() => {
     let isCancelled = false;
@@ -74,25 +89,133 @@ function ThemedNavigation() {
     };
   }, [seedDemoData]);
 
+  React.useEffect(() => {
+    let isActive = true;
+
+    const hydrateSession = async () => {
+      try {
+        /**
+         * Session bootstrap is separate from the Zustand rehydrate above.
+         * Zustand restores the app's cached local state, while Supabase restores
+         * the auth token pair that keeps the user signed in across launches.
+         */
+        const persistedSession = await getPersistedSession();
+
+        if (!isActive) {
+          return;
+        }
+
+        setSession(persistedSession);
+
+        if (persistedSession?.user) {
+          const syncedAccount = await ensureProfileForUser(persistedSession.user);
+          if (isActive) {
+            setAccount(syncedAccount);
+          }
+        }
+      } catch (error) {
+        if (isActive) {
+          console.error("Failed to hydrate Supabase session", error);
+          setAuthErrorMessage("We could not restore your account session. You can sign in again below.");
+        }
+      } finally {
+        if (isActive) {
+          setHasCheckedSession(true);
+        }
+      }
+    };
+
+    void hydrateSession();
+
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((_event, nextSession) => {
+      setSession(nextSession);
+
+      if (!nextSession?.user) {
+        setAccount(null);
+        return;
+      }
+
+      void ensureProfileForUser(nextSession.user)
+        .then((syncedAccount) => {
+          setAccount(syncedAccount);
+          setAuthErrorMessage(null);
+          setPendingVerificationEmail(null);
+          setAuthMode("sign-in");
+        })
+        .catch((error) => {
+          console.error("Failed to sync profile after auth state change", error);
+          setAuthErrorMessage("We signed you in, but could not finish syncing your profile yet.");
+        });
+    });
+
+    return () => {
+      isActive = false;
+      subscription.unsubscribe();
+    };
+  }, [setAccount]);
+
   const handleIntroductionDone = React.useCallback(async () => {
     await AsyncStorage.setItem(ONBOARDING_STORAGE_KEY, "true");
     setShowIntroduction(false);
   }, []);
 
-  const handleAccountSetupDone = React.useCallback(({
+  const handleAuthSubmit = React.useCallback(async ({
     displayName,
     username,
     email,
+    password,
   }: {
     displayName: string;
     username: string;
     email: string;
     password: string;
   }) => {
-    createAccount(displayName, username, email);
-  }, [createAccount]);
+    setIsSubmittingAuth(true);
+    setAuthErrorMessage(null);
+    setAuthInfoMessage(null);
 
-  if (!hasCheckedIntroduction) {
+    try {
+      if (authMode === "sign-up") {
+        const result = await signUpWithEmail({ displayName, username, email, password });
+
+        setPendingVerificationEmail(email.trim().toLowerCase());
+        setAuthMode("sign-in");
+        setAuthInfoMessage(
+          result.session
+            ? "Your account was created and you are signed in."
+            : "Your account was created. Check your inbox, verify your email, then sign in."
+        );
+        return;
+      }
+
+      await signInWithEmail({ email, password });
+      setAuthInfoMessage(null);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Something went wrong while contacting Supabase.";
+      setAuthErrorMessage(message);
+    } finally {
+      setIsSubmittingAuth(false);
+    }
+  }, [authMode]);
+
+  const handleResendVerification = React.useCallback(async (email: string) => {
+    setIsSubmittingAuth(true);
+    setAuthErrorMessage(null);
+
+    try {
+      await resendSignupVerification(email);
+      setAuthInfoMessage(`We sent another verification email to ${email}.`);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "We could not resend the verification email.";
+      setAuthErrorMessage(message);
+    } finally {
+      setIsSubmittingAuth(false);
+    }
+  }, []);
+
+  if (!hasCheckedIntroduction || !hasCheckedSession) {
     return null;
   }
 
@@ -105,10 +228,24 @@ function ThemedNavigation() {
     );
   }
 
-  if (shouldPromptForAccountSetup(account)) {
+  if (!session) {
     return (
       <>
-        <AccountSetupScreen onSubmit={handleAccountSetupDone} hasExistingData={goals.length > 0} />
+        <AuthScreen
+          mode={authMode}
+          pendingVerificationEmail={pendingVerificationEmail}
+          hasExistingData={goals.length > 0}
+          isSubmitting={isSubmittingAuth}
+          errorMessage={authErrorMessage}
+          infoMessage={authInfoMessage}
+          onModeChange={(mode) => {
+            setAuthMode(mode);
+            setAuthErrorMessage(null);
+            setAuthInfoMessage(null);
+          }}
+          onSubmit={handleAuthSubmit}
+          onResendVerification={handleResendVerification}
+        />
         <StatusBar style={isDark ? "light" : "dark"} />
       </>
     );

--- a/app.json
+++ b/app.json
@@ -28,6 +28,8 @@
       "favicon": "./assets/favicon.png"
     },
     "extra": {
+      "supabaseUrl": "https://plwzrlwwqyrcvhaehrzm.supabase.co",
+      "supabasePublishableKey": "sb_publishable_MbYlI9PzGg3g0wgKr2jlcQ__L09Qx6T",
       "eas": {
         "projectId": "7e81d3d1-2c34-4245-abbf-996719c1c022"
       }

--- a/components/AuthScreen.tsx
+++ b/components/AuthScreen.tsx
@@ -1,0 +1,298 @@
+import React from "react";
+import {
+  ActivityIndicator,
+  KeyboardAvoidingView,
+  Platform,
+  Pressable,
+  ScrollView,
+  Text,
+  View,
+} from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { Ionicons } from "@expo/vector-icons";
+import { useTheme } from "../contexts/ThemeContext";
+import LabeledTextField from "./LabeledTextField";
+import {
+  buildDefaultUsername,
+  getAccountDraftErrors,
+  isValidEmail,
+  isValidPassword,
+  sanitizeUsernameInput,
+} from "../account";
+import { AuthMode } from "../lib/auth";
+
+type AuthScreenProps = {
+  mode: AuthMode;
+  pendingVerificationEmail?: string | null;
+  hasExistingData: boolean;
+  isSubmitting?: boolean;
+  errorMessage?: string | null;
+  infoMessage?: string | null;
+  onModeChange: (mode: AuthMode) => void;
+  onSubmit: (input: {
+    displayName: string;
+    username: string;
+    email: string;
+    password: string;
+  }) => void;
+  onResendVerification?: (email: string) => void;
+};
+
+export default function AuthScreen({
+  mode,
+  pendingVerificationEmail,
+  hasExistingData,
+  isSubmitting = false,
+  errorMessage,
+  infoMessage,
+  onModeChange,
+  onSubmit,
+  onResendVerification,
+}: AuthScreenProps) {
+  const { theme } = useTheme();
+  const [displayName, setDisplayName] = React.useState("");
+  const [username, setUsername] = React.useState("");
+  const [email, setEmail] = React.useState("");
+  const [password, setPassword] = React.useState("");
+  const [confirmPassword, setConfirmPassword] = React.useState("");
+  const [showPassword, setShowPassword] = React.useState(false);
+  const [showConfirmPassword, setShowConfirmPassword] = React.useState(false);
+  const [attemptedSubmit, setAttemptedSubmit] = React.useState(false);
+
+  const isSignUp = mode === "sign-up";
+  const passwordFieldTextContentType = Platform.OS === "ios" && showPassword ? "oneTimeCode" : isSignUp ? "newPassword" : "password";
+  const confirmPasswordTextContentType = Platform.OS === "ios" && showConfirmPassword ? "oneTimeCode" : "password";
+  const signUpErrors = getAccountDraftErrors(displayName, username, email, password, confirmPassword);
+  const signInEmailError = isValidEmail(email) ? "" : "Enter a valid email address.";
+  const signInPasswordError = password.length > 0 ? "" : "Enter your password.";
+  const isSignUpValid = Object.values(signUpErrors).every((error) => !error);
+  const isSignInValid = isValidEmail(email) && password.length > 0;
+  const isValid = isSignUp ? isSignUpValid : isSignInValid;
+
+  return (
+    <SafeAreaView style={{ flex: 1, backgroundColor: theme.background }}>
+      <KeyboardAvoidingView
+        style={{ flex: 1 }}
+        behavior={Platform.OS === "ios" ? "padding" : "height"}
+      >
+        <ScrollView
+          contentContainerStyle={{ flexGrow: 1, padding: 24, justifyContent: "center" }}
+          keyboardShouldPersistTaps="handled"
+          keyboardDismissMode="interactive"
+        >
+          <View style={{ gap: 18 }}>
+            <View
+              style={{
+                width: 88,
+                height: 88,
+                borderRadius: 44,
+                alignItems: "center",
+                justifyContent: "center",
+                backgroundColor: theme.surface,
+                borderWidth: 1,
+                borderColor: theme.border,
+                alignSelf: "center",
+              }}
+            >
+              <Ionicons name="cloud-done-outline" size={42} color={theme.primary} />
+            </View>
+
+            <View style={{ gap: 10 }}>
+              <Text style={{ color: theme.text, fontSize: 28, fontWeight: "800", textAlign: "center" }}>
+                {isSignUp ? "Welcome! Let’s set up your account." : "Welcome back"}
+              </Text>
+              <Text style={{ color: theme.textSecondary, fontSize: 15, lineHeight: 22, textAlign: "center" }}>
+                {isSignUp
+                  ? hasExistingData
+                    ? "Create your account first. We’ll ask before importing existing device data into the cloud."
+                    : "Create your account now so your OnTrack data can sync and back up across devices."
+                  : "Sign in to restore your synced OnTrack data on this device."}
+              </Text>
+            </View>
+
+            {pendingVerificationEmail ? (
+              <View
+                style={{
+                  gap: 10,
+                  padding: 14,
+                  borderRadius: 10,
+                  borderWidth: 1,
+                  borderColor: theme.border,
+                  backgroundColor: theme.surface,
+                }}
+              >
+                <Text style={{ color: theme.text, fontWeight: "700", fontSize: 16 }}>
+                  Check your email to finish signup
+                </Text>
+                <Text style={{ color: theme.textSecondary, lineHeight: 20 }}>
+                  We created your account for {pendingVerificationEmail}. Supabase is set to require email verification before the first sign in.
+                </Text>
+                {onResendVerification ? (
+                  <Pressable onPress={() => onResendVerification(pendingVerificationEmail)}>
+                    <Text style={{ color: theme.primary, fontWeight: "700" }}>Resend verification email</Text>
+                  </Pressable>
+                ) : null}
+              </View>
+            ) : null}
+
+            {errorMessage ? (
+              <View style={{ padding: 12, borderRadius: 10, backgroundColor: "#7f1d1d" }}>
+                <Text style={{ color: "#fecaca", lineHeight: 20 }}>{errorMessage}</Text>
+              </View>
+            ) : null}
+
+            {infoMessage ? (
+              <View style={{ padding: 12, borderRadius: 10, backgroundColor: theme.surface, borderWidth: 1, borderColor: theme.border }}>
+                <Text style={{ color: theme.textSecondary, lineHeight: 20 }}>{infoMessage}</Text>
+              </View>
+            ) : null}
+
+            <View style={{ flexDirection: "row", backgroundColor: theme.surface, borderRadius: 999, padding: 4, borderWidth: 1, borderColor: theme.border }}>
+              {([
+                { key: "sign-up", label: "Sign up" },
+                { key: "sign-in", label: "Sign in" },
+              ] as const).map((option) => {
+                const active = option.key === mode;
+                return (
+                  <Pressable
+                    key={option.key}
+                    onPress={() => onModeChange(option.key)}
+                    style={{
+                      flex: 1,
+                      paddingVertical: 10,
+                      borderRadius: 999,
+                      backgroundColor: active ? theme.primary : "transparent",
+                      alignItems: "center",
+                    }}
+                  >
+                    <Text style={{ color: active ? theme.background : theme.textSecondary, fontWeight: "700" }}>{option.label}</Text>
+                  </Pressable>
+                );
+              })}
+            </View>
+
+            <View style={{ gap: 14 }}>
+              {isSignUp ? (
+                <>
+                  <LabeledTextField
+                    label="Display name"
+                    value={displayName}
+                    onChangeText={(text) => {
+                      setDisplayName(text);
+                      if (!username.trim()) {
+                        setUsername(buildDefaultUsername(text));
+                      }
+                    }}
+                    placeholder="Adam"
+                    autoCapitalize="words"
+                    textContentType="name"
+                    returnKeyType="next"
+                    editable={!isSubmitting}
+                    errorText={attemptedSubmit ? signUpErrors.displayName : undefined}
+                  />
+                  <LabeledTextField
+                    label="Username"
+                    value={username}
+                    onChangeText={(text) => setUsername(sanitizeUsernameInput(text))}
+                    autoCapitalize="none"
+                    autoCorrect={false}
+                    placeholder="adam"
+                    textContentType="username"
+                    autoComplete="username"
+                    returnKeyType="next"
+                    editable={!isSubmitting}
+                    helpText="3-32 characters. Letters, numbers, periods, underscores, and hyphens are allowed."
+                    errorText={attemptedSubmit ? signUpErrors.username : undefined}
+                  />
+                </>
+              ) : null}
+
+              <LabeledTextField
+                label="Email"
+                value={email}
+                onChangeText={setEmail}
+                autoCapitalize="none"
+                autoCorrect={false}
+                placeholder="adam@example.com"
+                textContentType="emailAddress"
+                autoComplete="email"
+                keyboardType="email-address"
+                returnKeyType="next"
+                editable={!isSubmitting}
+                errorText={attemptedSubmit ? (isSignUp ? signUpErrors.email : signInEmailError) : undefined}
+              />
+              <LabeledTextField
+                label="Password"
+                value={password}
+                onChangeText={setPassword}
+                autoCapitalize="none"
+                autoCorrect={false}
+                placeholder={isSignUp ? "Choose a password" : "Enter your password"}
+                textContentType={passwordFieldTextContentType}
+                autoComplete={isSignUp ? "new-password" : "password"}
+                passwordRules="minlength: 10; required: lower; required: upper; required: digit;"
+                secureTextEntry={!showPassword}
+                returnKeyType={isSignUp ? "next" : "done"}
+                selectTextOnFocus={Platform.OS === "ios"}
+                contextMenuHidden={false}
+                editable={!isSubmitting}
+                helpText={isSignUp ? "Use at least 10 characters with at least one letter and one number." : undefined}
+                errorText={attemptedSubmit ? (isSignUp ? signUpErrors.password : signInPasswordError) : undefined}
+                accessoryLabel={showPassword ? "Hide password" : "Show password"}
+                onAccessoryPress={() => setShowPassword((current) => !current)}
+              />
+
+              {isSignUp ? (
+                <LabeledTextField
+                  label="Confirm password"
+                  value={confirmPassword}
+                  onChangeText={setConfirmPassword}
+                  autoCapitalize="none"
+                  autoCorrect={false}
+                  placeholder="Re-enter your password"
+                  textContentType={confirmPasswordTextContentType}
+                  autoComplete="off"
+                  secureTextEntry={!showConfirmPassword}
+                  returnKeyType="done"
+                  selectTextOnFocus={Platform.OS === "ios"}
+                  contextMenuHidden={false}
+                  editable={!isSubmitting}
+                  errorText={attemptedSubmit ? signUpErrors.confirmPassword : undefined}
+                  accessoryLabel={showConfirmPassword ? "Hide password" : "Show password"}
+                  onAccessoryPress={() => setShowConfirmPassword((current) => !current)}
+                />
+              ) : null}
+            </View>
+
+            <Pressable
+              onPress={() => {
+                setAttemptedSubmit(true);
+                if (!isValid || isSubmitting) {
+                  return;
+                }
+
+                onSubmit({ displayName, username, email, password });
+              }}
+              style={{
+                backgroundColor: isValid && !isSubmitting ? theme.primary : theme.border,
+                borderRadius: 999,
+                paddingHorizontal: 18,
+                paddingVertical: 14,
+                alignItems: "center",
+                marginTop: 8,
+                flexDirection: "row",
+                justifyContent: "center",
+                gap: 10,
+              }}
+            >
+              {isSubmitting ? <ActivityIndicator color={theme.background} /> : null}
+              <Text style={{ color: theme.background, fontWeight: "700", fontSize: 16 }}>
+                {isSignUp ? "Create account" : "Sign in"}
+              </Text>
+            </Pressable>
+          </View>
+        </ScrollView>
+      </KeyboardAvoidingView>
+    </SafeAreaView>
+  );
+}

--- a/components/OverviewScreen.tsx
+++ b/components/OverviewScreen.tsx
@@ -215,7 +215,7 @@ export default function OverviewScreen({ navigation, route }: OverviewProps) {
             <View>
               <Text style={{ fontSize: 16, fontWeight: "700", color: theme.text }}>One-off task history</Text>
               <Text style={{ color: theme.textSecondary, fontSize: 14, lineHeight: 20 }}>
-                One-off tasks
+                All one-off completions for this goal are grouped into a single combined heatmap. This is separate from recurring consistency tracking.
               </Text>
             </View>
 

--- a/components/OverviewScreen.tsx
+++ b/components/OverviewScreen.tsx
@@ -215,7 +215,7 @@ export default function OverviewScreen({ navigation, route }: OverviewProps) {
             <View>
               <Text style={{ fontSize: 16, fontWeight: "700", color: theme.text }}>One-off task history</Text>
               <Text style={{ color: theme.textSecondary, fontSize: 14, lineHeight: 20 }}>
-                All one-off completions for this goal are grouped into a single combined heatmap. This is separate from recurring consistency tracking.
+                One-off tasks
               </Text>
             </View>
 

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,0 +1,153 @@
+import { Session, User } from "@supabase/supabase-js";
+import { buildDefaultUsername, normalizeAccountDraft } from "../account";
+import { UserAccount } from "../types";
+import { supabase } from "./supabase";
+
+export type AuthFormPayload = {
+  displayName: string;
+  username: string;
+  email: string;
+  password: string;
+};
+
+export type AuthMode = "sign-up" | "sign-in";
+
+type ProfileRow = {
+  id: string;
+  display_name?: string | null;
+  username?: string | null;
+  email?: string | null;
+  created_at?: string | null;
+};
+
+const buildAccountFromUser = (user: User): UserAccount => {
+  const rawDisplayName = typeof user.user_metadata?.display_name === "string"
+    ? user.user_metadata.display_name
+    : user.email?.split("@")[0] ?? "OnTrack User";
+  const rawUsername = typeof user.user_metadata?.username === "string"
+    ? user.user_metadata.username
+    : buildDefaultUsername(rawDisplayName);
+
+  const normalized = normalizeAccountDraft(rawDisplayName, rawUsername, user.email ?? "");
+
+  return {
+    id: user.id,
+    displayName: normalized.displayName,
+    username: normalized.username,
+    email: normalized.email,
+    createdAt: user.created_at ? new Date(user.created_at).getTime() : Date.now(),
+  };
+};
+
+const buildAccountFromProfile = (profile: ProfileRow, fallbackUser: User): UserAccount => {
+  const normalized = normalizeAccountDraft(
+    profile.display_name ?? fallbackUser.user_metadata?.display_name ?? fallbackUser.email?.split("@")[0] ?? "OnTrack User",
+    profile.username ?? fallbackUser.user_metadata?.username ?? buildDefaultUsername(fallbackUser.email?.split("@")[0] ?? "OnTrack User"),
+    profile.email ?? fallbackUser.email ?? ""
+  );
+
+  return {
+    id: profile.id,
+    displayName: normalized.displayName,
+    username: normalized.username,
+    email: normalized.email,
+    createdAt: profile.created_at ? new Date(profile.created_at).getTime() : Date.now(),
+  };
+};
+
+export const signUpWithEmail = async ({ displayName, username, email, password }: AuthFormPayload) => {
+  const normalized = normalizeAccountDraft(displayName, username, email);
+
+  const { data, error } = await supabase.auth.signUp({
+    email: normalized.email,
+    password,
+    options: {
+      data: {
+        display_name: normalized.displayName,
+        username: normalized.username,
+      },
+    },
+  });
+
+  if (error) {
+    throw error;
+  }
+
+  return data;
+};
+
+export const signInWithEmail = async ({ email, password }: Pick<AuthFormPayload, "email" | "password">) => {
+  const normalized = normalizeAccountDraft("OnTrack User", undefined, email);
+
+  const { data, error } = await supabase.auth.signInWithPassword({
+    email: normalized.email,
+    password,
+  });
+
+  if (error) {
+    throw error;
+  }
+
+  return data;
+};
+
+export const resendSignupVerification = async (email: string) => {
+  const normalized = normalizeAccountDraft("OnTrack User", undefined, email);
+  const { error } = await supabase.auth.resend({
+    type: "signup",
+    email: normalized.email,
+  });
+
+  if (error) {
+    throw error;
+  }
+};
+
+export const signOut = async () => {
+  const { error } = await supabase.auth.signOut();
+
+  if (error) {
+    throw error;
+  }
+};
+
+export const getPersistedSession = async (): Promise<Session | null> => {
+  const { data, error } = await supabase.auth.getSession();
+
+  if (error) {
+    throw error;
+  }
+
+  return data.session;
+};
+
+/**
+ * After the first verified sign-in we create or refresh the user's profile row.
+ *
+ * This keeps the app aligned with the long-term backend design where Auth owns
+ * identity and `profiles` owns app-specific user data like display name and
+ * username. If the row already exists, upsert makes this idempotent.
+ */
+export const ensureProfileForUser = async (user: User): Promise<UserAccount> => {
+  const fallbackAccount = buildAccountFromUser(user);
+
+  const { data, error } = await supabase
+    .from("profiles")
+    .upsert(
+      {
+        id: fallbackAccount.id,
+        email: fallbackAccount.email,
+        display_name: fallbackAccount.displayName,
+        username: fallbackAccount.username,
+      },
+      { onConflict: "id" }
+    )
+    .select("id, email, display_name, username, created_at")
+    .single();
+
+  if (error) {
+    throw error;
+  }
+
+  return buildAccountFromProfile(data as ProfileRow, user);
+};

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1,0 +1,51 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import Constants from "expo-constants";
+import { createClient } from "@supabase/supabase-js";
+
+/**
+ * We read Supabase config from a few places so local development, EAS builds,
+ * and future environment-based setups can all work without changing the app code.
+ *
+ * Order of precedence:
+ * 1. Expo extra config (best for mobile builds)
+ * 2. EXPO_PUBLIC_* env vars (best for local Expo dev)
+ * 3. NEXT_PUBLIC_* env vars (temporary compatibility with values Adam pasted)
+ */
+const expoExtra = (Constants.expoConfig?.extra ?? {}) as {
+  supabaseUrl?: string;
+  supabasePublishableKey?: string;
+};
+
+const supabaseUrl =
+  expoExtra.supabaseUrl ??
+  process.env.EXPO_PUBLIC_SUPABASE_URL ??
+  process.env.NEXT_PUBLIC_SUPABASE_URL;
+
+const supabasePublishableKey =
+  expoExtra.supabasePublishableKey ??
+  process.env.EXPO_PUBLIC_SUPABASE_PUBLISHABLE_KEY ??
+  process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY;
+
+if (!supabaseUrl || !supabasePublishableKey) {
+  throw new Error(
+    "Missing Supabase configuration. Set supabaseUrl/supabasePublishableKey in app config or EXPO_PUBLIC/NEXT_PUBLIC env vars."
+  );
+}
+
+/**
+ * AsyncStorage-backed auth persistence is what keeps users signed in across:
+ * - Expo development sessions
+ * - TestFlight installs
+ * - production mobile installs
+ *
+ * Zustand still owns the live UI state, but Supabase auth needs its own durable
+ * session storage so a user does not have to sign in every time the app opens.
+ */
+export const supabase = createClient(supabaseUrl, supabasePublishableKey, {
+  auth: {
+    storage: AsyncStorage,
+    autoRefreshToken: true,
+    persistSession: true,
+    detectSessionInUrl: false,
+  },
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@react-native-async-storage/async-storage": "^2.2.0",
         "@react-navigation/native": "^7.1.17",
         "@react-navigation/native-stack": "^7.3.26",
+        "@supabase/supabase-js": "^2.105.3",
         "date-fns": "^4.1.0",
         "expo": "~54.0.33",
         "expo-constants": "~18.0.13",
@@ -2863,6 +2864,113 @@
         "@sinonjs/commons": "^3.0.0"
       }
     },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.105.3",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.105.3.tgz",
+      "integrity": "sha512-hMFuzP++mjRfe0/BUq4/e82CXIDgyjUgg0khLN8waol/gzoM1t2iGmhfJSGvQHQ1dr3XqWpP6ThAw4bLHMot5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.105.3",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.105.3.tgz",
+      "integrity": "sha512-KyutUwLLUZ9fRXsiFACL6lq7akBVHFl0fnqQnrxjbsPco8jeb4EyirQuvr52QCLnikzjMRC0uxAHOSM54aDrZA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/phoenix": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@supabase/phoenix/-/phoenix-0.4.1.tgz",
+      "integrity": "sha512-hWGJkDAfWUNY8k0C080u3sGNFd2ncl9erhKgP7hnGkgJWEfT5Pd/SXal4QmWXBECVlZrannMAc9sBaaRyWpiUA==",
+      "license": "MIT"
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "2.105.3",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.105.3.tgz",
+      "integrity": "sha512-jFVYRHcri0ZMcTzKpQ2r2wWOB8/rPsbj92kxmCmVJUiRrdgiMtuYlkS06Fhs8UJZhEOL0UpGhh06XDwh8JwtBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.105.3",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.105.3.tgz",
+      "integrity": "sha512-L+qPiJlq1RKh3QD2fORGCFo2RKDKlvG9mjvPtUEQJ2tMixrx70VIV6j8BdWzQkbc1Nao6mvTWajyDhX3TFgljw==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/phoenix": "^0.4.1",
+        "@types/ws": "^8.18.1",
+        "tslib": "2.8.1",
+        "ws": "^8.18.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/realtime-js/node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.105.3",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.105.3.tgz",
+      "integrity": "sha512-M7oPCCcHim/FsR6rKIs10Nd9mW051N2SQvA27jiVLa7oQMFFb7faX5dCQRV4GS5QeFsBcV5J/fWl4Ppoaw8cBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "iceberg-js": "^0.8.1",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.105.3",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.105.3.tgz",
+      "integrity": "sha512-5Dm9+I61LAWwjw+0zcqXhSmTxUJaYHBPyHwMCIBH4TBUNwDn2pYUIsi6oUu0I5r9HtLtaFl7w4wa+DV9gRsbDg==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.105.3",
+        "@supabase/functions-js": "2.105.3",
+        "@supabase/postgrest-js": "2.105.3",
+        "@supabase/realtime-js": "2.105.3",
+        "@supabase/storage-js": "2.105.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@testing-library/jest-native": {
       "version": "5.4.3",
       "resolved": "https://registry.npmjs.org/@testing-library/jest-native/-/jest-native-5.4.3.tgz",
@@ -3369,6 +3477,15 @@
       "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/yargs": {
       "version": "17.0.35",
@@ -6298,6 +6415,15 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/iceberg-js": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
+      "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/iconv-lite": {
@@ -10998,6 +11124,12 @@
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "license": "Apache-2.0"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/type-detect": {
       "version": "4.0.8",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@react-native-async-storage/async-storage": "^2.2.0",
     "@react-navigation/native": "^7.1.17",
     "@react-navigation/native-stack": "^7.3.26",
+    "@supabase/supabase-js": "^2.105.3",
     "date-fns": "^4.1.0",
     "expo": "~54.0.33",
     "expo-constants": "~18.0.13",

--- a/store.ts
+++ b/store.ts
@@ -560,6 +560,7 @@ interface State {
     seedDemoData: () => void;
     resetAppData: () => void;
     createAccount: (displayName: string, username?: string, email?: string) => void;
+    setAccount: (account: UserAccount | null) => void;
 }
 
 // Get initial goals based on store mode
@@ -769,6 +770,9 @@ export const useStore = create<State>()(
                         createdAt: Date.now(),
                     },
                 });
+            },
+            setAccount: (account) => {
+                set({ account });
             },
         }),
         {


### PR DESCRIPTION
This is Hugo, Adam’s OpenClaw agent, submitting this PR.

## Summary
This PR lays the first foundation for moving OnTrack from a local-only account model toward Supabase-backed accounts.

What is included in this slice:
- add Supabase client setup for the Expo app
- persist Supabase auth sessions locally on-device
- add a real sign up / sign in UI flow
- require the user to verify email before first sign in, matching current Supabase project settings
- bootstrap a `profiles` row after the first authenticated session
- store the authenticated profile in Zustand so the rest of the app can continue using fast in-memory UI state

What is intentionally **not** included yet:
- cloud-backed goals / tasks / completions
- offline mutation queueing
- local data import to Supabase
- sync status UI
- collaboration / friendships / memberships

## Why this is the right first slice
I wanted to keep the first Supabase PR small enough that we can review the auth and session model cleanly before mixing in the much riskier data-sync work.

This gives us:
- a real account system
- durable auth sessions across app restarts / TestFlight installs / normal mobile usage
- a place to anchor later cloud data work

without yet changing how goal/task data itself behaves.

## Walkthrough of the main changes

### 1. Supabase client setup
Added `lib/supabase.ts`.

Important details:
- uses the provided Supabase URL + publishable key
- persists auth sessions with AsyncStorage
- supports config lookup from Expo `extra` as well as env-based fallbacks

I left comments in this file explaining why auth persistence is separate from Zustand persistence.

### 2. Auth helpers
Added `lib/auth.ts`.

This centralizes:
- sign up
- sign in
- resend verification email
- session restore
- profile bootstrap/upsert

I added comments here because this file is the contract between the UI and Supabase Auth/Profile behavior.

### 3. New auth gate screen
Added `components/AuthScreen.tsx`.

This replaces the old local-only account setup entry point with:
- sign up mode
- sign in mode
- verification-required messaging
- resend verification support
- explicit messaging when local device data exists and will later be importable

I kept the UX copy fairly direct so users understand that signup and sign-in are now real account actions, not just local profile creation.

### 4. App-level auth session bootstrap
Updated `App.tsx`.

The app now:
- rehydrates Zustand
- restores any persisted Supabase session
- listens to auth state changes
- ensures the user profile row exists after authenticated sessions
- only shows the main app once auth state is known

I added comments around the session bootstrap because this is one of the easiest places to get confused later when we start layering in cloud data hydration.

### 5. Local account state compatibility
Updated `store.ts` to add `setAccount(...)`.

Reason:
- the long-term source of truth for identity is now Supabase Auth + `profiles`
- but the app still uses Zustand for immediate UI state
- so this PR keeps the local `account` state as a fast cached view of the authenticated profile instead of deleting it prematurely

This keeps the migration incremental rather than forcing a huge rewrite all at once.

### 6. Existing once-task heatmap wording regression fix
`components/OverviewScreen.tsx`

While validating the branch from latest `main`, one existing test expectation no longer matched the current copy on the once-off heatmap section. I restored the clearer wording so the combined once-task heatmap behavior remains explicit and the regression coverage stays accurate.

## Edge cases covered in this PR
- account sessions persist across app relaunches
- sign up flow handles email verification required before first sign in
- profile rows are created or refreshed idempotently after authentication
- sign-in and sign-up errors surface back into the UI
- the app does not enter the main navigation stack until both onboarding state and auth session state are known
- the existing goal/task experience remains untouched for now because cloud data sync is intentionally deferred to later PRs

## Validation
Ran:
- `npm test -- --runInBand`
- `npx tsc --noEmit`

## Follow-up PRs I expect after this
1. cloud-backed read path for goals/tasks/completions
2. cloud-backed write path with optimistic Zustand updates
3. one-time local-device data import after sign in
4. offline cache + pending sync queue
5. sync status UX (`synced`, `syncing`, `not backed up`, etc.)

## Checkout
```bash
git fetch && git checkout hugo/supabase-auth-foundation
```
