### PR TITLE
feat: remove seeded demo onboarding

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -41,7 +41,6 @@ const Stack = createNativeStackNavigator<RootStackParamList>();
 function ThemedNavigation() {
   const { theme, isDark } = useTheme();
   const goals = useStore((s) => s.goals);
-  const seedDemoData = useStore((s) => s.seedDemoData);
   const setAccount = useStore((s) => s.setAccount);
   const [showIntroduction, setShowIntroduction] = React.useState(false);
   const [hasCheckedIntroduction, setHasCheckedIntroduction] = React.useState(false);
@@ -77,7 +76,6 @@ function ThemedNavigation() {
         return;
       }
 
-      seedDemoData();
       setShowIntroduction(true);
       setHasCheckedIntroduction(true);
     };
@@ -87,7 +85,7 @@ function ThemedNavigation() {
     return () => {
       isCancelled = true;
     };
-  }, [seedDemoData]);
+  }, []);
 
   React.useEffect(() => {
     let isActive = true;

--- a/components/InstructionsScreen.tsx
+++ b/components/InstructionsScreen.tsx
@@ -74,12 +74,12 @@ export default function InstructionsScreen() {
         </View>
 
         <View style={{ ...sectionStyle, borderColor: theme.border, backgroundColor: theme.surface }}>
-          <Text style={{ fontSize: 16, fontWeight: "700", color: theme.text }}>6. Example data and reset</Text>
+          <Text style={{ fontSize: 16, fontWeight: "700", color: theme.text }}>6. Start with your own goals</Text>
           <Text style={{ color: theme.textSecondary, lineHeight: 22 }}>
-            New users may see example goals and tasks so the charts and consistency pages make sense immediately. They are there to teach the flow, not to stay forever.
+            After onboarding and account setup, OnTrack starts empty. Add your own goals and tasks to build a consistency history that reflects your real routine.
           </Text>
           <Text style={{ color: theme.textSecondary, lineHeight: 22 }}>
-            When you are ready to start with your own data, open Settings and use Reset App Data. That clears the examples and your local history on this device.
+            If you ever want to clear your local history on this device and start over, open Settings and use Reset App Data.
           </Text>
         </View>
       </ScrollView>

--- a/components/IntroductionWizard.tsx
+++ b/components/IntroductionWizard.tsx
@@ -20,7 +20,7 @@ const slides: Slide[] = [
   {
     key: "welcome",
     title: "Welcome! Let’s get you On Track",
-    text: "This quick walkthrough will show you how the app works using demo goals and sample progress, so everything makes sense right away.",
+    text: "This quick walkthrough will show you how goals, tasks, and consistency tracking work so you can start fresh with your own data.",
     icon: "rocket-outline",
   },
   {
@@ -36,16 +36,16 @@ const slides: Slide[] = [
     icon: "repeat-outline",
   },
   {
-    key: "demo",
-    title: "Start by exploring demo data",
-    text: "New users get example goals, tasks, and history so the charts and consistency views make sense immediately instead of feeling empty.",
+    key: "consistency",
+    title: "Consistency builds over time",
+    text: "Your charts and consistency views will start empty, then fill in naturally as you log real completions for your own goals.",
     icon: "sparkles-outline",
   },
   {
-    key: "reset",
-    title: "IMPORTANT! Reset when you are ready",
-    text: "These are intro goals so you can see how OnTrack is set up. When you are done exploring, open Settings and tap Reset App Data to clear the demo data and start fresh.",
-    icon: "warning-outline",
+    key: "start",
+    title: "Start with a clean slate",
+    text: "After the walkthrough and account setup, the app opens empty so you can add your own goals right away instead of clearing example data first.",
+    icon: "checkmark-circle-outline",
   },
 ];
 

--- a/store.ts
+++ b/store.ts
@@ -557,7 +557,6 @@ interface State {
     toggleTaskCompletion: (goalId: string, taskId: string, date?: Date) => void;
     completionsByDate: () => Record<string, number>;
     deleteGoal: (goalId: string) => void;
-    seedDemoData: () => void;
     resetAppData: () => void;
     createAccount: (displayName: string, username?: string, email?: string) => void;
     setAccount: (account: UserAccount | null) => void;
@@ -734,18 +733,6 @@ export const useStore = create<State>()(
                 set((s) => ({
                     goals: s.goals.filter((g) => g.id !== goalId),
                 }));
-            },
-            seedDemoData: () => {
-                set((s) => {
-                    if (s.goals.length > 0) {
-                        return s;
-                    }
-
-                    return {
-                        goals: getSampleGoals(),
-                        selectedDate: normalizeDate(new Date()),
-                    };
-                });
             },
             resetAppData: () => {
                 set((s) => ({


### PR DESCRIPTION
This is Hugo, Adam’s OpenClaw agent, submitting this PR.

## Summary
- removes the seeded demo-data handoff from first-run onboarding
- keeps the intro walkthrough, but no longer injects example goals/tasks into the app state
- updates intro/help copy so the app now clearly communicates that users start with an empty slate after onboarding and account setup

## Edge cases covered
- true first launch still shows onboarding
- users who have already completed onboarding still skip it
- the app no longer depends on seeded goals to finish the walkthrough path

## Validation
- `npm test -- --runInBand tests/onboarding.test.ts tests/store.test.ts`
- `npx tsc --noEmit`

## Checkout
`git fetch && git checkout hugo/remove-seed-demo-onboarding`
