### PR TITLE
refactor: share app navigation route types

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -16,6 +16,8 @@ import InstructionsScreen from "./components/InstructionsScreen";
 import IntroductionWizard from "./components/IntroductionWizard";
 import AuthScreen from "./components/AuthScreen";
 import ImportLocalDataScreen from "./components/ImportLocalDataScreen";
+import { RootStackParamList } from "./navigation";
+import { RootStackParamList } from "./navigation";
 import { ONBOARDING_STORAGE_KEY, shouldShowOnboarding } from "./onboarding";
 import { useStore } from "./store";
 import {
@@ -29,15 +31,6 @@ import {
 import { fetchRemoteGoalsForUser } from "./lib/dataSync";
 import { replaceRemoteGoalsForUser } from "./lib/dataSync";
 import { supabase } from "./lib/supabase";
-
-type RootStackParamList = {
-  Home: undefined;
-  Goal: { goalId: string };
-  NewGoal: undefined;
-  Consistency: { goalId: string };
-  Privacy: undefined;
-  Instructions: undefined;
-};
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
 

--- a/App.tsx
+++ b/App.tsx
@@ -17,7 +17,6 @@ import IntroductionWizard from "./components/IntroductionWizard";
 import AuthScreen from "./components/AuthScreen";
 import ImportLocalDataScreen from "./components/ImportLocalDataScreen";
 import { RootStackParamList } from "./navigation";
-import { RootStackParamList } from "./navigation";
 import { ONBOARDING_STORAGE_KEY, shouldShowOnboarding } from "./onboarding";
 import { useStore } from "./store";
 import {

--- a/components/GoalScreen.tsx
+++ b/components/GoalScreen.tsx
@@ -9,13 +9,7 @@ import { useTheme } from "../contexts/ThemeContext";
 import { format, startOfWeek, endOfWeek, isWithinInterval, isToday } from "date-fns";
 import { Frequency, CustomFrequency } from "../types";
 import { haptics } from "../utils/haptics";
-
-type RootStackParamList = {
-  Home: undefined;
-  Goal: { goalId: string };
-  NewGoal: undefined;
-  Consistency: { goalId: string };
-};
+import { RootStackParamList } from "../navigation";
 
 type GoalProps = NativeStackScreenProps<RootStackParamList, "Goal">;
 

--- a/components/HomeScreen.tsx
+++ b/components/HomeScreen.tsx
@@ -11,16 +11,8 @@ import RadarChart from "./RadarChart";
 import DateContextCard from "./DateContextCard";
 import CalendarModal from "./CalendarModal";
 import { haptics } from "../utils/haptics";
+import { RootStackParamList } from "../navigation";
 import { RadarChartMode } from "./RadarChart";
-
-type RootStackParamList = {
-  Home: undefined;
-  Goal: { goalId: string };
-  NewGoal: undefined;
-  Consistency: { goalId: string };
-  Privacy: undefined;
-  Instructions: undefined;
-};
 
 type HomeProps = NativeStackScreenProps<RootStackParamList, "Home">;
 

--- a/components/NewGoalScreen.tsx
+++ b/components/NewGoalScreen.tsx
@@ -5,14 +5,8 @@ import { SafeAreaView } from "react-native-safe-area-context";
 import { useStore } from "../store";
 import { useTheme } from "../contexts/ThemeContext";
 import { haptics } from "../utils/haptics";
+import { RootStackParamList } from "../navigation";
 import LabeledTextField from "./LabeledTextField";
-
-type RootStackParamList = {
-  Home: undefined;
-  Goal: { goalId: string };
-  NewGoal: undefined;
-  Consistency: { goalId: string };
-};
 
 type NewGoalProps = NativeStackScreenProps<RootStackParamList, "NewGoal">;
 

--- a/components/OverviewScreen.tsx
+++ b/components/OverviewScreen.tsx
@@ -8,13 +8,7 @@ import { useStore, getCustomFrequencyProgress, getGoalStreak } from "../store";
 import { useTheme } from "../contexts/ThemeContext";
 import Heatmap from "./Heatmap";
 import { format } from "date-fns";
-
-type RootStackParamList = {
-  Home: undefined;
-  Goal: { goalId: string };
-  NewGoal: undefined;
-  Consistency: { goalId: string };
-};
+import { RootStackParamList } from "../navigation";
 
 type OverviewProps = NativeStackScreenProps<RootStackParamList, "Consistency">;
 

--- a/navigation.ts
+++ b/navigation.ts
@@ -1,0 +1,8 @@
+export type RootStackParamList = {
+  Home: undefined;
+  Goal: { goalId: string };
+  NewGoal: undefined;
+  Consistency: { goalId: string };
+  Privacy: undefined;
+  Instructions: undefined;
+};


### PR DESCRIPTION
This is Hugo, Adam’s OpenClaw agent, submitting this PR.

## Summary
- extracts the app stack route types into a single shared `navigation.ts` source
- updates `App.tsx`, `HomeScreen`, `NewGoalScreen`, `GoalScreen`, and `OverviewScreen` to import the canonical type instead of redefining it inline
- keeps runtime navigation behavior unchanged while making future route mismatches easier for TypeScript to catch

## Validation
- `npm test -- --runInBand tests/store.test.ts tests/radarChart.test.ts`
- `npx tsc --noEmit`

Closes #67.
