### PR TITLE
refactor: share info section cards

### DIFF
--- a/components/InfoSection.tsx
+++ b/components/InfoSection.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+import { Text, View } from "react-native";
+import { useTheme } from "../contexts/ThemeContext";
+
+type InfoSectionProps = {
+  title: string;
+  children: React.ReactNode;
+};
+
+export default function InfoSection({ title, children }: InfoSectionProps) {
+  const { theme } = useTheme();
+
+  return (
+    <View
+      style={{
+        borderWidth: 1,
+        borderColor: theme.border,
+        borderRadius: 12,
+        padding: 14,
+        backgroundColor: theme.surface,
+        gap: 8,
+      }}
+    >
+      <Text style={{ fontSize: 16, fontWeight: "700", color: theme.text }}>{title}</Text>
+      {children}
+    </View>
+  );
+}

--- a/components/InstructionsScreen.tsx
+++ b/components/InstructionsScreen.tsx
@@ -2,13 +2,7 @@ import React from "react";
 import { Text, View, ScrollView } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useTheme } from "../contexts/ThemeContext";
-
-const sectionStyle = {
-  borderWidth: 1,
-  borderRadius: 12,
-  padding: 14,
-  gap: 8,
-} as const;
+import InfoSection from "./InfoSection";
 
 export default function InstructionsScreen() {
   const { theme } = useTheme();
@@ -23,65 +17,59 @@ export default function InstructionsScreen() {
           </Text>
         </View>
 
-        <View style={{ ...sectionStyle, borderColor: theme.border, backgroundColor: theme.surface }}>
-          <Text style={{ fontSize: 16, fontWeight: "700", color: theme.text }}>1. Build a goal from tasks</Text>
+        <InfoSection title="1. Build a goal from tasks">
           <Text style={{ color: theme.textSecondary, lineHeight: 22 }}>
             A goal is the outcome you care about, like fitness, recovery, or learning. Tasks are the actions that support it.
           </Text>
           <Text style={{ color: theme.textSecondary, lineHeight: 22 }}>
             Example: a Fitness goal might include Daily water, Workout 3 times a week, and a 10k run once a month.
           </Text>
-        </View>
+        </InfoSection>
 
-        <View style={{ ...sectionStyle, borderColor: theme.border, backgroundColor: theme.surface }}>
-          <Text style={{ fontSize: 16, fontWeight: "700", color: theme.text }}>2. Pick the date you want to view</Text>
+        <InfoSection title="2. Pick the date you want to view">
           <Text style={{ color: theme.textSecondary, lineHeight: 22 }}>
             The date card on the home screen controls the app’s current tracking day. Tap it to open the calendar, switch to a past day, and then mark tasks for that day.
           </Text>
           <Text style={{ color: theme.textSecondary, lineHeight: 22 }}>
             This is useful for backfilling missed check-ins or logging progress from before you installed the app.
           </Text>
-        </View>
+        </InfoSection>
 
-        <View style={{ ...sectionStyle, borderColor: theme.border, backgroundColor: theme.surface }}>
-          <Text style={{ fontSize: 16, fontWeight: "700", color: theme.text }}>3. Understand task frequencies</Text>
+        <InfoSection title="3. Understand task frequencies">
           <Text style={{ color: theme.textSecondary, lineHeight: 22 }}>
             Daily tasks can be completed once per day. Weekly tasks need one completion during the current Sunday-to-Saturday week. Custom tasks use calendar-based weekly or monthly targets, such as 3 times per week or once per month.
           </Text>
           <Text style={{ color: theme.textSecondary, lineHeight: 22 }}>
             One-off tasks are different: they are single completions, so they appear separately from recurring consistency habits.
           </Text>
-        </View>
+        </InfoSection>
 
-        <View style={{ ...sectionStyle, borderColor: theme.border, backgroundColor: theme.surface }}>
-          <Text style={{ fontSize: 16, fontWeight: "700", color: theme.text }}>4. Read the heatmaps</Text>
+        <InfoSection title="4. Read the heatmaps">
           <Text style={{ color: theme.textSecondary, lineHeight: 22 }}>
             Heatmaps show when completions happened over time. More highlighted days means you showed up more consistently.
           </Text>
           <Text style={{ color: theme.textSecondary, lineHeight: 22 }}>
             Open a goal and tap See Consistency to view task-level heatmaps. Recurring tasks each get their own heatmap, while one-off tasks are grouped into a single combined heatmap at the bottom of the page.
           </Text>
-        </View>
+        </InfoSection>
 
-        <View style={{ ...sectionStyle, borderColor: theme.border, backgroundColor: theme.surface }}>
-          <Text style={{ fontSize: 16, fontWeight: "700", color: theme.text }}>5. Read the radar chart</Text>
+        <InfoSection title="5. Read the radar chart">
           <Text style={{ color: theme.textSecondary, lineHeight: 22 }}>
             The radar chart on the home screen gives a high-level comparison across goals. Bigger values mean that goal has been completed more consistently relative to its task expectations.
           </Text>
           <Text style={{ color: theme.textSecondary, lineHeight: 22 }}>
             It is useful for spotting which areas of your life are strong and which goals are falling behind.
           </Text>
-        </View>
+        </InfoSection>
 
-        <View style={{ ...sectionStyle, borderColor: theme.border, backgroundColor: theme.surface }}>
-          <Text style={{ fontSize: 16, fontWeight: "700", color: theme.text }}>6. Start with your own goals</Text>
+        <InfoSection title="6. Start with your own goals">
           <Text style={{ color: theme.textSecondary, lineHeight: 22 }}>
             After onboarding and account setup, OnTrack starts empty. Add your own goals and tasks to build a consistency history that reflects your real routine.
           </Text>
           <Text style={{ color: theme.textSecondary, lineHeight: 22 }}>
             If you ever want to clear your local history on this device and start over, open Settings and use Reset App Data.
           </Text>
-        </View>
+        </InfoSection>
       </ScrollView>
     </SafeAreaView>
   );

--- a/components/PrivacyScreen.tsx
+++ b/components/PrivacyScreen.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Text, View, ScrollView } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useTheme } from "../contexts/ThemeContext";
+import InfoSection from "./InfoSection";
 
 export default function PrivacyScreen() {
   const { theme } = useTheme();
@@ -16,26 +17,23 @@ export default function PrivacyScreen() {
           </Text>
         </View>
 
-        <View style={{ borderWidth: 1, borderColor: theme.border, borderRadius: 12, padding: 14, backgroundColor: theme.surface, gap: 8 }}>
-          <Text style={{ fontSize: 16, fontWeight: "700", color: theme.text }}>What the app stores</Text>
+        <InfoSection title="What the app stores">
           <Text style={{ color: theme.textSecondary, lineHeight: 22 }}>
             Goal titles, optional targets, task frequency settings, completion history, and your theme preference.
           </Text>
-        </View>
+        </InfoSection>
 
-        <View style={{ borderWidth: 1, borderColor: theme.border, borderRadius: 12, padding: 14, backgroundColor: theme.surface, gap: 8 }}>
-          <Text style={{ fontSize: 16, fontWeight: "700", color: theme.text }}>What the app does not do</Text>
+        <InfoSection title="What the app does not do">
           <Text style={{ color: theme.textSecondary, lineHeight: 22 }}>
             OnTrack does not require an account, does not include advertising, and does not send your goal data to a server from this app build.
           </Text>
-        </View>
+        </InfoSection>
 
-        <View style={{ borderWidth: 1, borderColor: theme.border, borderRadius: 12, padding: 14, backgroundColor: theme.surface, gap: 8 }}>
-          <Text style={{ fontSize: 16, fontWeight: "700", color: theme.text }}>Managing your data</Text>
+        <InfoSection title="Managing your data">
           <Text style={{ color: theme.textSecondary, lineHeight: 22 }}>
             You can remove the data stored by the app at any time from Settings by using Reset App Data.
           </Text>
-        </View>
+        </InfoSection>
       </ScrollView>
     </SafeAreaView>
   );


### PR DESCRIPTION
This is Hugo, Adam’s OpenClaw agent, submitting this PR.

## Summary
- extracts a small shared `InfoSection` primitive for bordered content cards with a title
- reuses that primitive in the instructions and privacy screens
- trims repeated inline view/text styling without changing screen behavior

## Notes
- kept the extraction intentionally narrow and low-risk
- focused on static screens first, per the issue guidance

## Validation
- `npm test -- --runInBand tests/onboarding.test.ts tests/store.test.ts`
- `npx tsc --noEmit`

## Checkout
`git fetch && git checkout hugo/issue-72-shared-info-sections`

Closes #72.
