### PR TITLE
feat: add local goal day notes

### DIFF
--- a/components/Heatmap.tsx
+++ b/components/Heatmap.tsx
@@ -8,13 +8,15 @@ interface HMProps {
   startOffsetDays?: number;            // how many days back to show
   values: Record<string, number>;      // yyyy-MM-dd -> count
   referenceDate?: Date;
+  notedDates?: string[];
 }
 
-export default function Heatmap({ startOffsetDays = 120, values, referenceDate = new Date() }: HMProps) {
+export default function Heatmap({ startOffsetDays = 120, values, referenceDate = new Date(), notedDates = [] }: HMProps) {
   const scrollViewRef = useRef<ScrollView>(null);
   const { theme, isDark } = useTheme();
   const focusDate = referenceDate;
   const today = new Date();
+  const notedDateSet = new Set(notedDates);
   
   // Calculate start date and adjust to the previous Sunday to ensure Sunday is always top row
   const roughStart = subDays(today, startOffsetDays);
@@ -130,6 +132,7 @@ export default function Heatmap({ startOffsetDays = 120, values, referenceDate =
               const y = gap + row * (cell + gap);
               const n = values[d] || 0;
               const isFocusDate = d === format(focusDate, "yyyy-MM-dd");
+              const hasNote = notedDateSet.has(d);
               
               return (
                 <React.Fragment key={d}>
@@ -149,6 +152,15 @@ export default function Heatmap({ startOffsetDays = 120, values, referenceDate =
                       cy={y + cell/2}
                       r={2}
                       fill={theme.primary}
+                    />
+                  )}
+                  {hasNote && (
+                    <Circle
+                      cx={x + cell - 3}
+                      cy={y + 3}
+                      r={1.75}
+                      fill={theme.textSecondary}
+                      opacity={0.9}
                     />
                   )}
                 </React.Fragment>

--- a/components/InstructionsScreen.tsx
+++ b/components/InstructionsScreen.tsx
@@ -61,6 +61,9 @@ export default function InstructionsScreen() {
           <Text style={{ color: theme.textSecondary, lineHeight: 22 }}>
             Open a goal and tap See Consistency to view task-level heatmaps. Recurring tasks each get their own heatmap, while one-off tasks are grouped into a single combined heatmap at the bottom of the page.
           </Text>
+          <Text style={{ color: theme.textSecondary, lineHeight: 22 }}>
+            You can also save a short local note for the selected day to explain a blank or unusual day without creating a fake completion.
+          </Text>
         </View>
 
         <View style={{ ...sectionStyle, borderColor: theme.border, backgroundColor: theme.surface }}>

--- a/components/OverviewScreen.tsx
+++ b/components/OverviewScreen.tsx
@@ -1,10 +1,10 @@
 import React from "react";
 import { NativeStackScreenProps } from "@react-navigation/native-stack";
-import { Text, View, ScrollView } from "react-native";
+import { Text, View, ScrollView, TextInput, Pressable } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { Ionicons } from "@expo/vector-icons";
 import Svg, { Circle } from "react-native-svg";
-import { useStore, getCustomFrequencyProgress, getGoalStreak } from "../store";
+import { useStore, getCustomFrequencyProgress, getGoalDayNoteKey, getGoalStreak } from "../store";
 import { useTheme } from "../contexts/ThemeContext";
 import Heatmap from "./Heatmap";
 import { format } from "date-fns";
@@ -20,8 +20,19 @@ export default function OverviewScreen({ navigation, route }: OverviewProps) {
   const streakRingCircumference = 2 * Math.PI * streakRingRadius;
   const { goalId } = route.params;
   const goal = useStore((s) => s.goals.find((g) => g.id === goalId)!);
+  const goalDayNotes = useStore((s) => s.goalDayNotes);
   const selectedDate = useStore((s) => s.selectedDate);
+  const setGoalDayNote = useStore((s) => s.setGoalDayNote);
+  const clearGoalDayNote = useStore((s) => s.clearGoalDayNote);
   const { theme } = useTheme();
+  const selectedDateKey = format(selectedDate, "yyyy-MM-dd");
+  const selectedNoteKey = getGoalDayNoteKey(goalId, selectedDate);
+  const savedNote = goalDayNotes[selectedNoteKey] ?? "";
+  const [noteDraft, setNoteDraft] = React.useState(savedNote);
+
+  React.useEffect(() => {
+    setNoteDraft(savedNote);
+  }, [savedNote, selectedNoteKey]);
 
   if (!goal) return <Text>Goal not found</Text>;
 
@@ -36,9 +47,15 @@ export default function OverviewScreen({ navigation, route }: OverviewProps) {
 
   const recurringTasks = goal.tasks.filter((task) => task.frequency !== "once");
   const onceTasks = goal.tasks.filter((task) => task.frequency === "once");
+  const notedDates = Object.keys(goalDayNotes)
+    .filter((key) => key.startsWith(`${goalId}:`))
+    .map((key) => key.split(":")[1]);
   const onceTaskHeatmapData = getHeatmapData(onceTasks.flatMap((task) => task.completions));
   const onceTaskCompletionCount = Object.values(onceTaskHeatmapData).reduce((sum, count) => sum + count, 0);
   const hasOnceTaskHistory = onceTaskCompletionCount > 0;
+  const trimmedDraft = noteDraft.trim();
+  const hasSavedNote = savedNote.length > 0;
+  const hasUnsavedChanges = trimmedDraft !== savedNote;
 
   return (
     <SafeAreaView style={{ flex: 1, backgroundColor: theme.background }} edges={['bottom', 'left', 'right']}>
@@ -48,6 +65,103 @@ export default function OverviewScreen({ navigation, route }: OverviewProps) {
           <Text style={{ color: theme.textSecondary, marginTop: 4 }}>
             Recurring task heatmaps and streaks
           </Text>
+        </View>
+
+        <View
+          style={{
+            borderWidth: 1,
+            borderColor: theme.border,
+            borderRadius: 10,
+            padding: 12,
+            backgroundColor: theme.surface,
+            gap: 10,
+          }}
+        >
+          <View style={{ flexDirection: "row", justifyContent: "space-between", alignItems: "center", gap: 12 }}>
+            <View style={{ flex: 1 }}>
+              <Text style={{ fontSize: 16, fontWeight: "700", color: theme.text }}>Day note</Text>
+              <Text style={{ color: theme.textSecondary, fontSize: 13, lineHeight: 19 }}>
+                Add short local context for {format(selectedDate, "MMM d, yyyy")} without affecting completions or scoring.
+              </Text>
+            </View>
+            {hasSavedNote ? (
+              <View
+                style={{
+                  flexDirection: "row",
+                  alignItems: "center",
+                  gap: 6,
+                  borderWidth: 1,
+                  borderColor: theme.border,
+                  borderRadius: 9999,
+                  paddingHorizontal: 8,
+                  paddingVertical: 4,
+                }}
+              >
+                <Ionicons name="document-text-outline" size={14} color={theme.textSecondary} />
+                <Text style={{ color: theme.textSecondary, fontSize: 12, fontWeight: "700" }}>Saved</Text>
+              </View>
+            ) : null}
+          </View>
+
+          <TextInput
+            value={noteDraft}
+            onChangeText={(value) => setNoteDraft(value.slice(0, 160))}
+            placeholder="Optional note, like travel day, planned rest, or illness"
+            placeholderTextColor={theme.textSecondary}
+            multiline
+            textAlignVertical="top"
+            style={{
+              minHeight: 84,
+              borderWidth: 1,
+              borderColor: theme.border,
+              borderRadius: 10,
+              padding: 12,
+              color: theme.text,
+              backgroundColor: theme.background,
+            }}
+          />
+
+          <View style={{ flexDirection: "row", justifyContent: "space-between", alignItems: "center", gap: 12 }}>
+            <Text style={{ color: theme.textSecondary, fontSize: 12 }}>
+              {noteDraft.length}/160 characters{hasSavedNote ? ` • visible on ${selectedDateKey}` : ""}
+            </Text>
+
+            <View style={{ flexDirection: "row", gap: 8 }}>
+              {hasSavedNote ? (
+                <Pressable
+                  onPress={() => {
+                    clearGoalDayNote(goalId, selectedDate);
+                    setNoteDraft("");
+                  }}
+                  style={{
+                    borderWidth: 1,
+                    borderColor: theme.border,
+                    borderRadius: 9999,
+                    paddingHorizontal: 12,
+                    paddingVertical: 8,
+                  }}
+                >
+                  <Text style={{ color: theme.text, fontWeight: "700" }}>Clear</Text>
+                </Pressable>
+              ) : null}
+
+              <Pressable
+                onPress={() => setGoalDayNote(goalId, selectedDate, noteDraft)}
+                disabled={!trimmedDraft || !hasUnsavedChanges}
+                style={{
+                  borderRadius: 9999,
+                  paddingHorizontal: 12,
+                  paddingVertical: 8,
+                  backgroundColor: !trimmedDraft || !hasUnsavedChanges ? theme.border : theme.primary,
+                  opacity: !trimmedDraft || !hasUnsavedChanges ? 0.7 : 1,
+                }}
+              >
+                <Text style={{ color: !trimmedDraft || !hasUnsavedChanges ? theme.textSecondary : theme.background, fontWeight: "700" }}>
+                  Save note
+                </Text>
+              </Pressable>
+            </View>
+          </View>
         </View>
 
         {recurringTasks.length === 0 ? (
@@ -189,6 +303,7 @@ export default function OverviewScreen({ navigation, route }: OverviewProps) {
                 startOffsetDays={180} 
                 values={getHeatmapData(task.completions)}
                 referenceDate={selectedDate}
+                notedDates={notedDates}
               />
             </View>
             {index < recurringTasks.length - 1 && <View style={{ height: 16 }} />}
@@ -222,6 +337,7 @@ export default function OverviewScreen({ navigation, route }: OverviewProps) {
                 startOffsetDays={180}
                 values={onceTaskHeatmapData}
                 referenceDate={selectedDate}
+                notedDates={notedDates}
               />
             ) : (
               <View

--- a/components/PrivacyScreen.tsx
+++ b/components/PrivacyScreen.tsx
@@ -19,7 +19,7 @@ export default function PrivacyScreen() {
         <View style={{ borderWidth: 1, borderColor: theme.border, borderRadius: 12, padding: 14, backgroundColor: theme.surface, gap: 8 }}>
           <Text style={{ fontSize: 16, fontWeight: "700", color: theme.text }}>What the app stores</Text>
           <Text style={{ color: theme.textSecondary, lineHeight: 22 }}>
-            Goal titles, optional targets, task frequency settings, completion history, and your theme preference.
+            Goal titles, optional targets, task frequency settings, completion history, optional local day notes, and your theme preference.
           </Text>
         </View>
 

--- a/store.ts
+++ b/store.ts
@@ -1,7 +1,7 @@
 import { create } from "zustand";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { persist, createJSONStorage } from "zustand/middleware";
-import { Goal, Frequency, CustomFrequency, Task, UserAccount } from "./types";
+import { Goal, Frequency, CustomFrequency, Task, UserAccount, GoalDayNotes } from "./types";
 import { format, startOfDay, startOfWeek, endOfWeek, startOfMonth, endOfMonth, isWithinInterval, differenceInCalendarDays } from "date-fns";
 import { normalizeAccountDraft } from "./account";
 
@@ -22,7 +22,14 @@ type PersistedGoal = Omit<Goal, "tasks"> & {
 
 type PersistedStoreSnapshot = {
   goals?: PersistedGoal[];
+  goalDayNotes?: GoalDayNotes;
 };
+
+const MAX_GOAL_DAY_NOTE_LENGTH = 160;
+
+export const getGoalDayNoteKey = (goalId: string, date: Date): string => `${goalId}:${dateToKey(date)}`;
+
+const normalizeGoalDayNote = (note: string): string => note.trim().slice(0, MAX_GOAL_DAY_NOTE_LENGTH);
 
 const normalizeTask = (task: PersistedTask): Task => ({
   ...task,
@@ -589,6 +596,7 @@ export const getCurrentMode = () => CURRENT_MODE;
 
 interface State {
     goals: Goal[];
+    goalDayNotes: GoalDayNotes;
     selectedDate: Date;
     account: UserAccount | null;
     cloudSyncEnabled: boolean;
@@ -600,6 +608,8 @@ interface State {
     addGoal: (title: string, target?: string) => void;
     reorderGoals: (goalIdsInOrder: string[]) => void;
     setSelectedDate: (date: Date) => void;
+    setGoalDayNote: (goalId: string, date: Date, note: string) => void;
+    clearGoalDayNote: (goalId: string, date: Date) => void;
     updateGoal: (goalId: string, updates: { title?: string; target?: string | null }) => void;
     addTask: (goalId: string, title: string, frequency: Frequency, customFrequency?: CustomFrequency) => void;
     updateTask: (goalId: string, taskId: string, updates: { title?: string; frequency?: Frequency; customFrequency?: CustomFrequency | undefined }) => void;
@@ -638,6 +648,7 @@ export const useStore = create<State>()(
     persist(
         (set, get) => ({
             goals: getInitialGoals(), // Dynamic initialization based on store mode
+            goalDayNotes: {},
             selectedDate: normalizeDate(new Date()),
             account: null,
             cloudSyncEnabled: false,
@@ -698,6 +709,38 @@ export const useStore = create<State>()(
             setSelectedDate: (date) =>
                 set({
                     selectedDate: normalizeDate(date),
+                }),
+            setGoalDayNote: (goalId, date, note) =>
+                set((s) => {
+                    const key = getGoalDayNoteKey(goalId, date);
+                    const normalizedNote = normalizeGoalDayNote(note);
+
+                    if (!normalizedNote) {
+                        const { [key]: _removed, ...remainingNotes } = s.goalDayNotes;
+                        return { goalDayNotes: remainingNotes };
+                    }
+
+                    if (s.goalDayNotes[key] === normalizedNote) {
+                        return s;
+                    }
+
+                    return {
+                        goalDayNotes: {
+                            ...s.goalDayNotes,
+                            [key]: normalizedNote,
+                        },
+                    };
+                }),
+            clearGoalDayNote: (goalId, date) =>
+                set((s) => {
+                    const key = getGoalDayNoteKey(goalId, date);
+
+                    if (!(key in s.goalDayNotes)) {
+                        return s;
+                    }
+
+                    const { [key]: _removed, ...remainingNotes } = s.goalDayNotes;
+                    return { goalDayNotes: remainingNotes };
                 }),
             updateGoal: (goalId, updates) =>
                 set((s) => ({
@@ -844,6 +887,9 @@ export const useStore = create<State>()(
             },
             deleteGoal: (goalId) => {
                 set((s) => ({
+                    goalDayNotes: Object.fromEntries(
+                        Object.entries(s.goalDayNotes).filter(([key]) => !key.startsWith(`${goalId}:`))
+                    ),
                     ...buildDirtyGoalState(
                         s.goals.filter((g) => g.id !== goalId),
                         s.syncRevision
@@ -853,6 +899,7 @@ export const useStore = create<State>()(
             resetAppData: () => {
                 set((s) => ({
                     goals: getInitialGoals(),
+                    goalDayNotes: {},
                     selectedDate: normalizeDate(new Date()),
                     account: s.account,
                     syncRevision: s.syncRevision + 1,

--- a/tests/store.test.ts
+++ b/tests/store.test.ts
@@ -1,4 +1,4 @@
-import { getCustomFrequencyProgress, getGoalProgress, getSampleGoals, isOnceTaskCompletedOnDate, useStore } from '../store';
+import { getCustomFrequencyProgress, getGoalDayNoteKey, getGoalProgress, getSampleGoals, isOnceTaskCompletedOnDate, useStore } from '../store';
 import { Goal, Task } from '../types';
 
 describe('getCustomFrequencyProgress', () => {
@@ -293,5 +293,92 @@ describe('updateGoal', () => {
     useStore.getState().updateGoal('goal-2', { target: null });
 
     expect(useStore.getState().goals[0].target).toBeUndefined();
+  });
+});
+
+describe('goal day notes', () => {
+  const originalState = useStore.getState();
+
+  beforeEach(() => {
+    useStore.setState({
+      ...originalState,
+      goals: [
+        {
+          id: 'goal-a',
+          title: 'Fitness',
+          createdAt: Date.now(),
+          tasks: [
+            {
+              id: 'task-a',
+              title: 'Walk',
+              frequency: 'daily',
+              completions: [new Date('2026-05-13T12:00:00.000Z')],
+            },
+          ],
+        },
+        {
+          id: 'goal-b',
+          title: 'Reading',
+          createdAt: Date.now(),
+          tasks: [],
+        },
+      ],
+      goalDayNotes: {},
+      selectedDate: new Date('2026-05-13T12:00:00.000Z'),
+    }, true);
+  });
+
+  afterEach(() => {
+    useStore.setState(originalState, true);
+  });
+
+  it('stores notes separately by goal and date', () => {
+    useStore.getState().setGoalDayNote('goal-a', new Date('2026-05-13T12:00:00.000Z'), 'Travel day');
+    useStore.getState().setGoalDayNote('goal-a', new Date('2026-05-14T12:00:00.000Z'), 'Recovery');
+    useStore.getState().setGoalDayNote('goal-b', new Date('2026-05-13T12:00:00.000Z'), 'Different goal');
+
+    expect(useStore.getState().goalDayNotes).toEqual({
+      [getGoalDayNoteKey('goal-a', new Date('2026-05-13T12:00:00.000Z'))]: 'Travel day',
+      [getGoalDayNoteKey('goal-a', new Date('2026-05-14T12:00:00.000Z'))]: 'Recovery',
+      [getGoalDayNoteKey('goal-b', new Date('2026-05-13T12:00:00.000Z'))]: 'Different goal',
+    });
+  });
+
+  it('updates, trims, and clears notes idempotently', () => {
+    useStore.getState().setGoalDayNote('goal-a', new Date('2026-05-13T12:00:00.000Z'), '  Sick day  ');
+    useStore.getState().setGoalDayNote('goal-a', new Date('2026-05-13T12:00:00.000Z'), 'Sick day');
+
+    expect(useStore.getState().goalDayNotes[getGoalDayNoteKey('goal-a', new Date('2026-05-13T12:00:00.000Z'))]).toBe('Sick day');
+
+    useStore.getState().clearGoalDayNote('goal-a', new Date('2026-05-13T12:00:00.000Z'));
+    useStore.getState().clearGoalDayNote('goal-a', new Date('2026-05-13T12:00:00.000Z'));
+
+    expect(useStore.getState().goalDayNotes).toEqual({});
+  });
+
+  it('does not affect goal progress calculations', () => {
+    const goal = useStore.getState().goals[0];
+    const before = getGoalProgress(goal, new Date('2026-05-13T18:00:00.000Z'));
+
+    useStore.getState().setGoalDayNote('goal-a', new Date('2026-05-13T12:00:00.000Z'), 'Planned light day');
+
+    const after = getGoalProgress(useStore.getState().goals[0], new Date('2026-05-13T18:00:00.000Z'));
+
+    expect(after).toEqual(before);
+  });
+
+  it('removes notes for a deleted goal and resets them with app data', () => {
+    useStore.getState().setGoalDayNote('goal-a', new Date('2026-05-13T12:00:00.000Z'), 'Travel day');
+    useStore.getState().setGoalDayNote('goal-b', new Date('2026-05-13T12:00:00.000Z'), 'Reading break');
+
+    useStore.getState().deleteGoal('goal-a');
+
+    expect(useStore.getState().goalDayNotes).toEqual({
+      [getGoalDayNoteKey('goal-b', new Date('2026-05-13T12:00:00.000Z'))]: 'Reading break',
+    });
+
+    useStore.getState().resetAppData();
+
+    expect(useStore.getState().goalDayNotes).toEqual({});
   });
 });

--- a/types.ts
+++ b/types.ts
@@ -28,3 +28,5 @@ export interface UserAccount {
   email: string;
   createdAt: number;
 }
+
+export type GoalDayNotes = Record<string, string>;


### PR DESCRIPTION
This is Hugo, Adam’s OpenClaw agent, submitting this PR.

## Summary
- adds local-only goal day notes keyed by goal and selected calendar date
- adds a compact note editor to the consistency screen for the active selected day
- shows subtle note markers in the goal heatmaps without changing completion intensity or scoring
- documents the feature in help/privacy copy and adds store regression coverage

## Notes
- notes stay local-only in this slice
- notes do not affect completions, streaks, radar values, heatmap counts, or goal progress
- the editing flow stays anchored to the existing selected date

## Validation
- `npm test -- --runInBand tests/store.test.ts tests/onboarding.test.ts`
- `npx tsc --noEmit`

## Checkout
`git fetch && git checkout hugo/issue-100-goal-day-notes`

Closes #100.
