### PR TITLE
test: expand radar and date context regressions

### DIFF
--- a/components/HomeScreen.tsx
+++ b/components/HomeScreen.tsx
@@ -3,7 +3,7 @@ import { NativeStackScreenProps } from "@react-navigation/native-stack";
 import { Text, View, Pressable, ScrollView, Alert, Switch, Modal, AppState } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { Ionicons } from '@expo/vector-icons';
-import { addDays, isToday, startOfDay, subDays } from "date-fns";
+import { isToday } from "date-fns";
 import DraggableFlatList, { RenderItemParams, ScaleDecorator } from "react-native-draggable-flatlist";
 import { useStore, debugAsyncStorage, getCurrentMode, getGoalProgress } from "../store";
 import { useTheme } from "../contexts/ThemeContext";
@@ -13,6 +13,7 @@ import CalendarModal from "./CalendarModal";
 import { haptics } from "../utils/haptics";
 import { RootStackParamList } from "../navigation";
 import { RadarChartMode } from "./RadarChart";
+import { getNextTrackingDate, getPreviousTrackingDate } from "../lib/dateContext";
 
 type HomeProps = NativeStackScreenProps<RootStackParamList, "Home">;
 
@@ -169,7 +170,7 @@ export default function HomeScreen({ navigation }: HomeProps) {
             }}
             onPreviousDay={() => {
               void haptics.tap();
-              setSelectedDate(subDays(selectedDate, 1));
+              setSelectedDate(getPreviousTrackingDate(selectedDate));
             }}
             onNextDay={() => {
               if (isToday(selectedDate)) {
@@ -178,9 +179,7 @@ export default function HomeScreen({ navigation }: HomeProps) {
               }
 
               void haptics.tap();
-              const nextDate = addDays(selectedDate, 1);
-              const today = startOfDay(new Date());
-              setSelectedDate(nextDate > today ? today : nextDate);
+              setSelectedDate(getNextTrackingDate(selectedDate));
             }}
           />
 

--- a/components/RadarChart.tsx
+++ b/components/RadarChart.tsx
@@ -40,18 +40,18 @@ export const getCurrentModeTaskScore = (
   return progress.target > 0 ? Math.min(1, progress.completed / progress.target) : 0;
 };
 
-const getDailyTrendScore = (completionDates: Date[], startDate: Date, referenceDate: Date) => {
+export const getDailyTrendScore = (completionDates: Date[], startDate: Date, referenceDate: Date) => {
   const days = Math.max(1, differenceInCalendarDays(referenceDate, startDate) + 1);
   return Math.min(1, completionDates.length / days);
 };
 
-const getWeeklyTrendScore = (completionDates: Date[], startDate: Date, referenceDate: Date) => {
+export const getWeeklyTrendScore = (completionDates: Date[], startDate: Date, referenceDate: Date) => {
   const days = Math.max(1, differenceInCalendarDays(referenceDate, startDate) + 1);
   const expectedWeeks = Math.max(1, Math.ceil(days / 7));
   return Math.min(1, completionDates.length / expectedWeeks);
 };
 
-const getCustomTrendScore = (completionDates: Date[], target: number, periodType: "weekly" | "monthly", startDate: Date, referenceDate: Date) => {
+export const getCustomTrendScore = (completionDates: Date[], target: number, periodType: "weekly" | "monthly", startDate: Date, referenceDate: Date) => {
   if (target <= 0) return 0;
 
   const days = Math.max(1, differenceInCalendarDays(referenceDate, startDate) + 1);

--- a/lib/dateContext.test.ts
+++ b/lib/dateContext.test.ts
@@ -1,0 +1,33 @@
+import { startOfDay } from "date-fns";
+import { getNextTrackingDate, getPreviousTrackingDate } from "./dateContext";
+
+describe("dateContext helpers", () => {
+  it("moves to the previous day", () => {
+    const result = getPreviousTrackingDate(new Date("2026-05-13T12:00:00.000Z"));
+
+    expect(result).toEqual(new Date("2026-05-12T12:00:00.000Z"));
+  });
+
+  it("moves to the next day when still in the past", () => {
+    const result = getNextTrackingDate(
+      new Date("2026-05-11T12:00:00.000Z"),
+      new Date("2026-05-13T18:00:00.000Z")
+    );
+
+    expect(result).toEqual(new Date("2026-05-12T12:00:00.000Z"));
+  });
+
+  it("clamps forward navigation to today instead of allowing a future date", () => {
+    const today = new Date("2026-05-13T18:00:00.000Z");
+    const result = getNextTrackingDate(new Date("2026-05-13T00:00:00.000Z"), today);
+
+    expect(result).toEqual(startOfDay(today));
+  });
+
+  it("returns today when the selected date is already today", () => {
+    const today = new Date("2026-05-13T18:00:00.000Z");
+    const result = getNextTrackingDate(startOfDay(today), today);
+
+    expect(result).toEqual(startOfDay(today));
+  });
+});

--- a/lib/dateContext.ts
+++ b/lib/dateContext.ts
@@ -1,0 +1,14 @@
+import { addDays, isToday, startOfDay, subDays } from "date-fns";
+
+export const getPreviousTrackingDate = (selectedDate: Date): Date => subDays(selectedDate, 1);
+
+export const getNextTrackingDate = (selectedDate: Date, today: Date = new Date()): Date => {
+  if (isToday(selectedDate)) {
+    return startOfDay(today);
+  }
+
+  const nextDate = addDays(selectedDate, 1);
+  const normalizedToday = startOfDay(today);
+
+  return nextDate > normalizedToday ? normalizedToday : nextDate;
+};

--- a/tests/radarChart.test.ts
+++ b/tests/radarChart.test.ts
@@ -1,5 +1,10 @@
 import { endOfDay } from "date-fns";
-import { getCurrentModeTaskScore } from "../components/RadarChart";
+import {
+  getCurrentModeTaskScore,
+  getCustomTrendScore,
+  getDailyTrendScore,
+  getWeeklyTrendScore,
+} from "../components/RadarChart";
 import { Task } from "../types";
 
 // Reference week: Sun 2026-04-19 – Sat 2026-04-25
@@ -92,5 +97,79 @@ describe("getCurrentModeTaskScore — daily vs custom consistency", () => {
 
     expect(customScore).toBe(1);
     expect(weeklyScore).toBe(1);
+  });
+});
+
+describe("trend score helpers", () => {
+  it("daily trend uses the active span from first completion through reference date", () => {
+    const completions = [
+      new Date("2026-04-20T12:00:00.000Z"),
+      new Date("2026-04-22T12:00:00.000Z"),
+    ];
+
+    const score = getDailyTrendScore(
+      completions,
+      new Date("2026-04-20T12:00:00.000Z"),
+      endOfDay(new Date("2026-04-22T12:00:00.000Z"))
+    );
+
+    expect(score).toBeCloseTo(2 / 3);
+  });
+
+  it("weekly trend treats a partial first week as one expected week", () => {
+    const completions = [new Date("2026-04-22T12:00:00.000Z")];
+
+    const score = getWeeklyTrendScore(
+      completions,
+      new Date("2026-04-22T12:00:00.000Z"),
+      endOfDay(new Date("2026-04-22T12:00:00.000Z"))
+    );
+
+    expect(score).toBe(1);
+  });
+
+  it("weekly trend expands expected weeks after crossing into a second week", () => {
+    const completions = [
+      new Date("2026-04-22T12:00:00.000Z"),
+      new Date("2026-04-29T12:00:00.000Z"),
+    ];
+
+    const score = getWeeklyTrendScore(
+      completions,
+      new Date("2026-04-22T12:00:00.000Z"),
+      endOfDay(new Date("2026-04-30T12:00:00.000Z"))
+    );
+
+    expect(score).toBe(1);
+  });
+
+  it("custom weekly trend uses target times expected weeks", () => {
+    const completions = [
+      new Date("2026-04-22T12:00:00.000Z"),
+      new Date("2026-04-24T12:00:00.000Z"),
+      new Date("2026-04-29T12:00:00.000Z"),
+    ];
+
+    const score = getCustomTrendScore(
+      completions,
+      2,
+      "weekly",
+      new Date("2026-04-22T12:00:00.000Z"),
+      endOfDay(new Date("2026-04-30T12:00:00.000Z"))
+    );
+
+    expect(score).toBeCloseTo(3 / 4);
+  });
+
+  it("custom monthly trend returns 0 when target is invalid", () => {
+    const score = getCustomTrendScore(
+      [new Date("2026-04-22T12:00:00.000Z")],
+      0,
+      "monthly",
+      new Date("2026-04-22T12:00:00.000Z"),
+      endOfDay(new Date("2026-04-30T12:00:00.000Z"))
+    );
+
+    expect(score).toBe(0);
   });
 });


### PR DESCRIPTION
This is Hugo, Adam’s OpenClaw agent, submitting this PR.

## Summary
- adds focused regression coverage for the selected-date navigation helpers and wires those helpers into `HomeScreen`
- expands radar trend regression coverage for daily, weekly, and custom-frequency branches
- covers partial-period and first-completion edge cases without relying on full screen runtime setup

## Edge cases covered
- moving backward one day from the selected date
- moving forward while still in the past
- clamping forward navigation so it cannot move beyond today
- daily trend scoring from the first completion through the current reference date
- weekly trend scoring for a partial first week and after crossing into a second week
- custom weekly trend scoring against expected periods and invalid-target handling

## Validation
- `npm test`
- `npx tsc --noEmit`

## Checkout
`git fetch && git checkout hugo/issue-50-radar-date-regressions`

Closes #50.
