### PR TITLE
feat: add goal consistency summary view

### DIFF
--- a/components/Heatmap.tsx
+++ b/components/Heatmap.tsx
@@ -67,8 +67,11 @@ export default function Heatmap({ startOffsetDays = 120, values, referenceDate =
 
     if (valueMode === "ratio") {
       const normalized = Math.max(0, Math.min(n, 1));
-      const alpha = 0.2 + (normalized * 0.8);
-      return `rgba(46, 237, 114, ${alpha.toFixed(3)})`;
+      if (normalized < 0.25) return "#d8f5df";
+      if (normalized < 0.5) return "#a6e3b5";
+      if (normalized < 0.75) return "#63c97c";
+      if (normalized < 1) return "#2ea85a";
+      return "#1f7a3f";
     }
 
     return "#2aed72ff";

--- a/components/Heatmap.tsx
+++ b/components/Heatmap.tsx
@@ -8,9 +8,10 @@ interface HMProps {
   startOffsetDays?: number;            // how many days back to show
   values: Record<string, number>;      // yyyy-MM-dd -> count
   referenceDate?: Date;
+  valueMode?: "count" | "ratio";
 }
 
-export default function Heatmap({ startOffsetDays = 120, values, referenceDate = new Date() }: HMProps) {
+export default function Heatmap({ startOffsetDays = 120, values, referenceDate = new Date(), valueMode = "count" }: HMProps) {
   const scrollViewRef = useRef<ScrollView>(null);
   const { theme, isDark } = useTheme();
   const focusDate = referenceDate;
@@ -63,6 +64,12 @@ export default function Heatmap({ startOffsetDays = 120, values, referenceDate =
 
   const scale = (n: number) => {
     if (n <= 0) return theme.border;
+
+    if (valueMode === "ratio") {
+      const normalized = Math.max(0, Math.min(n, 1));
+      const alpha = 0.2 + (normalized * 0.8);
+      return `rgba(46, 237, 114, ${alpha.toFixed(3)})`;
+    }
 
     return "#2aed72ff";
   };

--- a/components/OverviewScreen.tsx
+++ b/components/OverviewScreen.tsx
@@ -10,6 +10,14 @@ import Heatmap from "./Heatmap";
 import { format, startOfDay } from "date-fns";
 import { RootStackParamList } from "../navigation";
 
+const SUMMARY_HEATMAP_LEGEND = [
+  { color: "#d8f5df", label: "1-24%" },
+  { color: "#a6e3b5", label: "25-49%" },
+  { color: "#63c97c", label: "50-74%" },
+  { color: "#2ea85a", label: "75-99%" },
+  { color: "#1f7a3f", label: "100%" },
+] as const;
+
 type OverviewProps = NativeStackScreenProps<RootStackParamList, "Consistency">;
 
 export default function OverviewScreen({ navigation, route }: OverviewProps) {
@@ -131,6 +139,42 @@ export default function OverviewScreen({ navigation, route }: OverviewProps) {
               referenceDate={selectedDate}
               valueMode="ratio"
             />
+
+            <View style={{ gap: 6 }}>
+              <Text style={{ color: theme.textSecondary, fontSize: 12, fontWeight: "600" }}>
+                Completion scale
+              </Text>
+              <View style={{ flexDirection: "row", flexWrap: "wrap", gap: 8 }}>
+                {SUMMARY_HEATMAP_LEGEND.map((item) => (
+                  <View
+                    key={item.label}
+                    style={{
+                      flexDirection: "row",
+                      alignItems: "center",
+                      gap: 6,
+                      borderWidth: 1,
+                      borderColor: theme.border,
+                      borderRadius: 9999,
+                      paddingHorizontal: 8,
+                      paddingVertical: 4,
+                      backgroundColor: theme.background,
+                    }}
+                  >
+                    <View
+                      style={{
+                        width: 12,
+                        height: 12,
+                        borderRadius: 3,
+                        backgroundColor: item.color,
+                        borderWidth: 1,
+                        borderColor: theme.border,
+                      }}
+                    />
+                    <Text style={{ color: theme.textSecondary, fontSize: 12 }}>{item.label}</Text>
+                  </View>
+                ))}
+              </View>
+            </View>
           </View>
         ) : null}
 

--- a/components/OverviewScreen.tsx
+++ b/components/OverviewScreen.tsx
@@ -7,7 +7,7 @@ import Svg, { Circle } from "react-native-svg";
 import { useStore, getCustomFrequencyProgress, getGoalStreak } from "../store";
 import { useTheme } from "../contexts/ThemeContext";
 import Heatmap from "./Heatmap";
-import { format } from "date-fns";
+import { format, startOfDay } from "date-fns";
 import { RootStackParamList } from "../navigation";
 
 type OverviewProps = NativeStackScreenProps<RootStackParamList, "Consistency">;
@@ -35,9 +35,36 @@ export default function OverviewScreen({ navigation, route }: OverviewProps) {
     return heatmapData;
   };
 
+  const getRecurringGoalSummaryHeatmapData = () => {
+    if (recurringTasks.length === 0) {
+      return {} as Record<string, number>;
+    }
+
+    const completionsByDate: Record<string, Set<string>> = {};
+
+    recurringTasks.forEach((task) => {
+      task.completions.forEach((date) => {
+        const dateKey = format(startOfDay(date), "yyyy-MM-dd");
+
+        if (!completionsByDate[dateKey]) {
+          completionsByDate[dateKey] = new Set<string>();
+        }
+
+        completionsByDate[dateKey].add(task.id);
+      });
+    });
+
+    return Object.fromEntries(
+      Object.entries(completionsByDate).map(([dateKey, completedTaskIds]) => [
+        dateKey,
+        completedTaskIds.size / recurringTasks.length,
+      ])
+    );
+  };
+
   const recurringTasks = goal.tasks.filter((task) => task.frequency !== "once");
   const onceTasks = goal.tasks.filter((task) => task.frequency === "once");
-  const recurringGoalSummaryHeatmapData = getHeatmapData(recurringTasks.flatMap((task) => task.completions));
+  const recurringGoalSummaryHeatmapData = getRecurringGoalSummaryHeatmapData();
   const onceTaskHeatmapData = getHeatmapData(onceTasks.flatMap((task) => task.completions));
   const onceTaskCompletionCount = Object.values(onceTaskHeatmapData).reduce((sum, count) => sum + count, 0);
   const hasOnceTaskHistory = onceTaskCompletionCount > 0;
@@ -90,18 +117,19 @@ export default function OverviewScreen({ navigation, route }: OverviewProps) {
             <View>
               <Text style={{ fontSize: 16, fontWeight: "700", color: theme.text }}>Goal summary heatmap</Text>
               <Text style={{ color: theme.textSecondary, fontSize: 14, lineHeight: 20 }}>
-                Each day shows how many recurring tasks in this goal were completed on that date.
+                Each day shows what percentage of this goal’s recurring tasks were completed on that date.
               </Text>
             </View>
 
             <Text style={{ color: theme.textSecondary, fontSize: 13 }}>
-              Recurring tasks in this goal: {recurringTasks.length} • Total recurring completions: {Object.values(recurringGoalSummaryHeatmapData).reduce((sum, count) => sum + count, 0)}
+              Recurring tasks in this goal: {recurringTasks.length} • Darker green means a higher completion percentage for that day.
             </Text>
 
             <Heatmap
               startOffsetDays={180}
               values={recurringGoalSummaryHeatmapData}
               referenceDate={selectedDate}
+              valueMode="ratio"
             />
           </View>
         ) : null}

--- a/components/OverviewScreen.tsx
+++ b/components/OverviewScreen.tsx
@@ -130,7 +130,7 @@ export default function OverviewScreen({ navigation, route }: OverviewProps) {
             </View>
 
             <Text style={{ color: theme.textSecondary, fontSize: 13 }}>
-              Recurring tasks in this goal: {recurringTasks.length} • Darker green means a higher completion percentage for that day.
+              Recurring tasks in this goal: {recurringTasks.length}
             </Text>
 
             <Heatmap

--- a/components/OverviewScreen.tsx
+++ b/components/OverviewScreen.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { NativeStackScreenProps } from "@react-navigation/native-stack";
-import { Text, View, ScrollView } from "react-native";
+import { Text, View, ScrollView, Pressable } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { Ionicons } from "@expo/vector-icons";
 import Svg, { Circle } from "react-native-svg";
@@ -22,6 +22,7 @@ export default function OverviewScreen({ navigation, route }: OverviewProps) {
   const goal = useStore((s) => s.goals.find((g) => g.id === goalId)!);
   const selectedDate = useStore((s) => s.selectedDate);
   const { theme } = useTheme();
+  const [viewMode, setViewMode] = React.useState<"summary" | "tasks">("tasks");
 
   if (!goal) return <Text>Goal not found</Text>;
 
@@ -36,6 +37,7 @@ export default function OverviewScreen({ navigation, route }: OverviewProps) {
 
   const recurringTasks = goal.tasks.filter((task) => task.frequency !== "once");
   const onceTasks = goal.tasks.filter((task) => task.frequency === "once");
+  const recurringGoalSummaryHeatmapData = getHeatmapData(recurringTasks.flatMap((task) => task.completions));
   const onceTaskHeatmapData = getHeatmapData(onceTasks.flatMap((task) => task.completions));
   const onceTaskCompletionCount = Object.values(onceTaskHeatmapData).reduce((sum, count) => sum + count, 0);
   const hasOnceTaskHistory = onceTaskCompletionCount > 0;
@@ -46,11 +48,65 @@ export default function OverviewScreen({ navigation, route }: OverviewProps) {
         <View>
           <Text style={{ fontSize: 22, fontWeight: "800", color: theme.text }}>{goal.title} - Consistency</Text>
           <Text style={{ color: theme.textSecondary, marginTop: 4 }}>
-            Recurring task heatmaps and streaks
+            {viewMode === "summary" ? "Goal-level consistency summary" : "Recurring task heatmaps and streaks"}
           </Text>
         </View>
 
-        {recurringTasks.length === 0 ? (
+        <View style={{ flexDirection: "row", alignItems: "center", gap: 8 }}>
+          {([
+            { key: "summary", label: "Summary" },
+            { key: "tasks", label: "Per-task" },
+          ] as const).map((option) => (
+            <Pressable
+              key={option.key}
+              onPress={() => setViewMode(option.key)}
+              style={{
+                paddingHorizontal: 10,
+                paddingVertical: 6,
+                borderRadius: 9999,
+                borderWidth: 1,
+                borderColor: viewMode === option.key ? theme.primary : theme.border,
+                backgroundColor: viewMode === option.key ? theme.primary + "20" : theme.surface,
+              }}
+            >
+              <Text style={{ color: viewMode === option.key ? theme.primary : theme.textSecondary, fontWeight: "600", fontSize: 12 }}>
+                {option.label}
+              </Text>
+            </Pressable>
+          ))}
+        </View>
+
+        {viewMode === "summary" ? (
+          <View
+            style={{
+              borderWidth: 1,
+              borderColor: theme.border,
+              borderRadius: 10,
+              padding: 12,
+              backgroundColor: theme.surface,
+              gap: 10,
+            }}
+          >
+            <View>
+              <Text style={{ fontSize: 16, fontWeight: "700", color: theme.text }}>Goal summary heatmap</Text>
+              <Text style={{ color: theme.textSecondary, fontSize: 14, lineHeight: 20 }}>
+                Each day shows how many recurring tasks in this goal were completed on that date.
+              </Text>
+            </View>
+
+            <Text style={{ color: theme.textSecondary, fontSize: 13 }}>
+              Recurring tasks in this goal: {recurringTasks.length} • Total recurring completions: {Object.values(recurringGoalSummaryHeatmapData).reduce((sum, count) => sum + count, 0)}
+            </Text>
+
+            <Heatmap
+              startOffsetDays={180}
+              values={recurringGoalSummaryHeatmapData}
+              referenceDate={selectedDate}
+            />
+          </View>
+        ) : null}
+
+        {viewMode === "tasks" && recurringTasks.length === 0 ? (
           <View
             style={{
               borderWidth: 1,
@@ -68,7 +124,7 @@ export default function OverviewScreen({ navigation, route }: OverviewProps) {
           </View>
         ) : null}
 
-        {recurringTasks.map((task, index) => (
+        {viewMode === "tasks" && recurringTasks.map((task, index) => (
           <View key={task.id}>
             <View style={{ 
               borderWidth: 1, 
@@ -195,7 +251,7 @@ export default function OverviewScreen({ navigation, route }: OverviewProps) {
           </View>
         ))}
 
-        {onceTasks.length > 0 ? (
+        {viewMode === "tasks" && onceTasks.length > 0 ? (
           <View
             style={{
               borderWidth: 1,

--- a/overviewScreen.test.tsx
+++ b/overviewScreen.test.tsx
@@ -23,8 +23,12 @@ jest.mock('react-native-safe-area-context', () => {
 jest.mock('./components/Heatmap', () => {
   const React = require('react');
   const { Text } = require('react-native');
-  return function MockHeatmap() {
-    return <Text testID="heatmap">heatmap</Text>;
+  return function MockHeatmap(props: { valueMode?: string; values?: Record<string, number> }) {
+    return (
+      <Text testID="heatmap">
+        {JSON.stringify({ valueMode: props.valueMode ?? 'count', values: props.values ?? {} })}
+      </Text>
+    );
   };
 });
 
@@ -42,7 +46,7 @@ jest.mock('./contexts/ThemeContext', () => ({
 }));
 
 const mockState = {
-  selectedDate: new Date('2026-05-06T00:00:00.000Z'),
+  selectedDate: new Date('2026-05-06T12:00:00.000Z'),
   goals: [
     {
       id: 'goal-1',
@@ -53,19 +57,25 @@ const mockState = {
           id: 'recurring-1',
           title: 'Walk',
           frequency: 'daily' as const,
-          completions: [new Date('2026-05-05T00:00:00.000Z')],
+          completions: [new Date('2026-05-05T12:00:00.000Z')],
+        },
+        {
+          id: 'recurring-2',
+          title: 'Stretch',
+          frequency: 'daily' as const,
+          completions: [],
         },
         {
           id: 'once-1',
           title: 'Buy shoes',
           frequency: 'once' as const,
-          completions: [new Date('2026-05-04T00:00:00.000Z')],
+          completions: [new Date('2026-05-04T12:00:00.000Z')],
         },
         {
           id: 'once-2',
           title: 'Book physio',
           frequency: 'once' as const,
-          completions: [new Date('2026-05-03T00:00:00.000Z')],
+          completions: [new Date('2026-05-03T12:00:00.000Z')],
         },
       ],
     },
@@ -94,8 +104,10 @@ describe('OverviewScreen', () => {
     fireEvent.press(getByText('Summary'));
 
     expect(getByText('Goal summary heatmap')).toBeTruthy();
-    expect(getByText(/Each day shows how many recurring tasks/i)).toBeTruthy();
+    expect(getByText(/what percentage of this goal’s recurring tasks/i)).toBeTruthy();
     expect(getAllByTestId('heatmap')).toHaveLength(1);
+    expect(getByText(/"valueMode":"ratio"/)).toBeTruthy();
+    expect(getByText(/"2026-05-05":0.5/)).toBeTruthy();
     expect(queryByText('Walk')).toBeNull();
     expect(queryByText('One-off task history')).toBeNull();
   });
@@ -110,8 +122,9 @@ describe('OverviewScreen', () => {
 
     expect(getByText('One-off task history')).toBeTruthy();
     expect(getByText(/Once tasks in this goal:/i)).toBeTruthy();
-    expect(getAllByTestId('heatmap')).toHaveLength(2);
+    expect(getAllByTestId('heatmap')).toHaveLength(3);
     expect(getByText('Walk')).toBeTruthy();
+    expect(getByText('Stretch')).toBeTruthy();
     expect(queryByText('Buy shoes')).toBeNull();
     expect(queryByText('Book physio')).toBeNull();
   });

--- a/overviewScreen.test.tsx
+++ b/overviewScreen.test.tsx
@@ -105,6 +105,12 @@ describe('OverviewScreen', () => {
 
     expect(getByText('Goal summary heatmap')).toBeTruthy();
     expect(getByText(/what percentage of this goal’s recurring tasks/i)).toBeTruthy();
+    expect(getByText('Completion scale')).toBeTruthy();
+    expect(getByText('1-24%')).toBeTruthy();
+    expect(getByText('25-49%')).toBeTruthy();
+    expect(getByText('50-74%')).toBeTruthy();
+    expect(getByText('75-99%')).toBeTruthy();
+    expect(getByText('100%')).toBeTruthy();
     expect(getAllByTestId('heatmap')).toHaveLength(1);
     expect(getByText(/"valueMode":"ratio"/)).toBeTruthy();
     expect(getByText(/"2026-05-05":0.5/)).toBeTruthy();

--- a/overviewScreen.test.tsx
+++ b/overviewScreen.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render } from '@testing-library/react-native';
+import { fireEvent, render } from '@testing-library/react-native';
 import OverviewScreen from './components/OverviewScreen';
 
 jest.mock('@expo/vector-icons', () => ({
@@ -79,6 +79,27 @@ jest.mock('./store', () => ({
 }));
 
 describe('OverviewScreen', () => {
+  it('lets users switch to a goal-level summary heatmap', () => {
+    const { getByText, getAllByTestId, queryByText } = render(
+      <OverviewScreen
+        navigation={{} as never}
+        route={{ key: 'Consistency-1', name: 'Consistency', params: { goalId: 'goal-1' } } as never}
+      />,
+    );
+
+    expect(getByText('Per-task')).toBeTruthy();
+    expect(getByText('Summary')).toBeTruthy();
+    expect(queryByText('Goal summary heatmap')).toBeNull();
+
+    fireEvent.press(getByText('Summary'));
+
+    expect(getByText('Goal summary heatmap')).toBeTruthy();
+    expect(getByText(/Each day shows how many recurring tasks/i)).toBeTruthy();
+    expect(getAllByTestId('heatmap')).toHaveLength(1);
+    expect(queryByText('Walk')).toBeNull();
+    expect(queryByText('One-off task history')).toBeNull();
+  });
+
   it('renders one combined heatmap for all one-off tasks in a goal', () => {
     const { getAllByTestId, getByText, queryByText } = render(
       <OverviewScreen


### PR DESCRIPTION
This is Hugo, Adam’s OpenClaw agent, submitting this PR.

## Summary
- adds a toggle between the existing per-task consistency view and a simpler goal-level summary view
- renders a summary heatmap that shows how many recurring tasks in the goal were completed on each day
- keeps the existing per-task view available, including one-off task history, and adds regression coverage for switching views

## Notes
- the summary view uses recurring task completions only, so it stays aligned with the existing consistency framing
- the same selected-date reference marker continues to drive the heatmap focus state in both modes

## Validation
- `npm test`
- `npx tsc --noEmit`

## Checkout
`git fetch && git checkout hugo/issue-89-consistency-summary-view`

Closes #89.
