### PR TITLE
feat: add freeze days feature

### DIFF
--- a/components/DateContextCard.tsx
+++ b/components/DateContextCard.tsx
@@ -1,102 +1,218 @@
 import React from "react";
-import { Pressable, Text, View } from "react-native";
+import { Alert, Pressable, Text, View } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
-import { format, isToday } from "date-fns";
+import { format, isToday, isFuture } from "date-fns";
 import { useTheme } from "../contexts/ThemeContext";
+import { haptics } from "../utils/haptics";
 import IconButton from "./IconButton";
+import FreezeDayModal from "./FreezeDayModal";
 
 interface DateContextCardProps {
   selectedDate: Date;
+  isFrozen: boolean;
+  freezeReason?: string;
+  hasCompletions: boolean;
   onPress: () => void;
   onPreviousDay: () => void;
   onNextDay: () => void;
+  onFreezeDay: (reason: string) => void;
+  onUnfreezeDay: () => void;
 }
 
-export default function DateContextCard({ selectedDate, onPress, onPreviousDay, onNextDay }: DateContextCardProps) {
-  const { theme } = useTheme();
+export default function DateContextCard({
+  selectedDate,
+  isFrozen,
+  freezeReason,
+  hasCompletions,
+  onPress,
+  onPreviousDay,
+  onNextDay,
+  onFreezeDay,
+  onUnfreezeDay,
+}: DateContextCardProps) {
+  const { theme, isDark } = useTheme();
   const viewingToday = isToday(selectedDate);
+  const isFutureDate = isFuture(selectedDate);
+  const [showFreezeModal, setShowFreezeModal] = React.useState(false);
+
+  // Theme-aware frozen colors
+  const frozenBorderColor = isDark ? "#3b82f6" + "60" : "#60a5fa" + "60";
+  const frozenBgColor = isDark ? "#1e3a5f" + "20" : "#eff6ff" + "20";
+  const frozenIconBg = isDark ? "#3b82f6" + "25" : "#60a5fa" + "25";
+  const frozenTextColor = isDark ? "#93c5fd" : "#60a5fa";
+
+  const handleFreezePress = () => {
+    void haptics.tap();
+    setShowFreezeModal(true);
+  };
+
+  const handleFreezeConfirm = (reason: string) => {
+    setShowFreezeModal(false);
+    onFreezeDay(reason);
+  };
+
+  const handleFreezeCancel = () => {
+    setShowFreezeModal(false);
+  };
+
+  const handleUnfreezePress = () => {
+    void haptics.warning();
+    Alert.alert(
+      "Unfreeze this day?",
+      freezeReason ? `Reason: "${freezeReason}"\n\nRemoving the freeze will allow this day to affect your streaks again.` : "Removing the freeze will allow this day to affect your streaks again.",
+      [
+        { text: "Keep Frozen", style: "cancel" },
+        {
+          text: "Unfreeze",
+          style: "destructive",
+          onPress: () => {
+            void haptics.destructive();
+            onUnfreezeDay();
+          },
+        },
+      ]
+    );
+  };
 
   return (
-    <View
-      style={{
-        borderWidth: 1,
-        borderColor: theme.primary + "40",
-        borderRadius: 14,
-        padding: 14,
-        backgroundColor: theme.surface,
-        gap: 12,
-      }}
-    >
-      <View style={{ flexDirection: "row", alignItems: "center", justifyContent: "space-between", gap: 12 }}>
-        <View style={{ flexDirection: "row", alignItems: "center", gap: 12, flex: 1 }}>
-          <View
+    <>
+      <View
+        style={{
+          borderWidth: 1,
+          borderColor: isFrozen ? frozenBorderColor : theme.primary + "40",
+          borderRadius: 14,
+          padding: 14,
+          backgroundColor: isFrozen ? frozenBgColor : theme.surface,
+          gap: 12,
+        }}
+      >
+        <View style={{ flexDirection: "row", alignItems: "center", justifyContent: "space-between", gap: 12 }}>
+          <View style={{ flexDirection: "row", alignItems: "center", gap: 12, flex: 1 }}>
+            <View
+              style={{
+                width: 38,
+                height: 38,
+                borderRadius: 19,
+                alignItems: "center",
+                justifyContent: "center",
+                backgroundColor: isFrozen ? frozenIconBg : theme.primary + "15",
+              }}
+            >
+              {isFrozen ? (
+                <Text style={{ fontSize: 20 }}>❄️</Text>
+              ) : (
+                <Ionicons name="calendar-outline" size={18} color={theme.primary} />
+              )}
+            </View>
+            <View style={{ flex: 1 }}>
+              <Text style={{ color: theme.textSecondary, fontSize: 12, fontWeight: "600", textTransform: "uppercase", letterSpacing: 0.6 }}>
+                {isFrozen ? "Frozen Day" : "Tracking Date"}
+              </Text>
+              <Text style={{ color: theme.text, fontSize: 16, fontWeight: "700", marginTop: 2 }}>
+                {format(selectedDate, "EEEE, MMM d, yyyy")}
+              </Text>
+              {isFrozen && freezeReason ? (
+                <Text style={{ color: frozenTextColor, marginTop: 2, fontSize: 13 }} numberOfLines={2}>
+                  {freezeReason}
+                </Text>
+              ) : (
+                <Text style={{ color: theme.textSecondary, marginTop: 2 }}>
+                  {viewingToday ? "Tap to switch days" : "Viewing and editing this day"}
+                </Text>
+              )}
+            </View>
+          </View>
+          <IconButton icon="calendar-outline" onPress={onPress} padded />
+        </View>
+
+        <View style={{ flexDirection: "row", gap: 10 }}>
+          <Pressable
+            onPress={onPreviousDay}
             style={{
-              width: 38,
-              height: 38,
-              borderRadius: 19,
+              flex: 1,
+              flexDirection: "row",
               alignItems: "center",
               justifyContent: "center",
-              backgroundColor: theme.primary + "15",
+              gap: 6,
+              backgroundColor: theme.background,
+              borderWidth: 1,
+              borderColor: theme.border,
+              borderRadius: 10,
+              paddingVertical: 10,
             }}
           >
-            <Ionicons name="calendar-outline" size={18} color={theme.primary} />
-          </View>
-          <View style={{ flex: 1 }}>
-            <Text style={{ color: theme.textSecondary, fontSize: 12, fontWeight: "600", textTransform: "uppercase", letterSpacing: 0.6 }}>
-              Tracking Date
-            </Text>
-            <Text style={{ color: theme.text, fontSize: 16, fontWeight: "700", marginTop: 2 }}>
-              {format(selectedDate, "EEEE, MMM d, yyyy")}
-            </Text>
-            <Text style={{ color: theme.textSecondary, marginTop: 2 }}>
-              {viewingToday ? "Tap to switch days" : "Viewing and editing this day"}
-            </Text>
-          </View>
+            <Ionicons name="chevron-back" size={16} color={theme.text} />
+            <Text style={{ color: theme.text, fontWeight: "700" }}>Previous</Text>
+          </Pressable>
+
+          <Pressable
+            onPress={onNextDay}
+            disabled={viewingToday}
+            style={{
+              flex: 1,
+              flexDirection: "row",
+              alignItems: "center",
+              justifyContent: "center",
+              gap: 6,
+              backgroundColor: theme.background,
+              borderWidth: 1,
+              borderColor: theme.border,
+              borderRadius: 10,
+              paddingVertical: 10,
+              opacity: viewingToday ? 0.45 : 1,
+            }}
+          >
+            <Text style={{ color: theme.text, fontWeight: "700" }}>Next</Text>
+            <Ionicons name="chevron-forward" size={16} color={theme.text} />
+          </Pressable>
         </View>
-        <IconButton icon="calendar-outline" onPress={onPress} padded />
+
+        {/* Freeze / Unfreeze row - only for today or past dates without completions */}
+        {!isFutureDate && (isFrozen ? (
+          <Pressable
+            onPress={handleUnfreezePress}
+            style={{
+              flexDirection: "row",
+              alignItems: "center",
+              justifyContent: "center",
+              gap: 6,
+              backgroundColor: theme.background,
+              borderWidth: 1,
+              borderColor: frozenBorderColor,
+              borderRadius: 10,
+              paddingVertical: 10,
+            }}
+          >
+            <Text style={{ fontSize: 16 }}>❄️</Text>
+            <Text style={{ color: frozenTextColor, fontWeight: "700" }}>Day Frozen — Tap to Unfreeze</Text>
+          </Pressable>
+        ) : !hasCompletions ? (
+          <Pressable
+            onPress={handleFreezePress}
+            style={{
+              flexDirection: "row",
+              alignItems: "center",
+              justifyContent: "center",
+              gap: 6,
+              backgroundColor: theme.background,
+              borderWidth: 1,
+              borderColor: theme.border,
+              borderRadius: 10,
+              paddingVertical: 10,
+            }}
+          >
+            <Text style={{ fontSize: 16 }}>❄️</Text>
+            <Text style={{ color: theme.textSecondary, fontWeight: "600" }}>Freeze This Day</Text>
+          </Pressable>
+        ) : null)}
       </View>
 
-      <View style={{ flexDirection: "row", gap: 10 }}>
-        <Pressable
-          onPress={onPreviousDay}
-          style={{
-            flex: 1,
-            flexDirection: "row",
-            alignItems: "center",
-            justifyContent: "center",
-            gap: 6,
-            backgroundColor: theme.background,
-            borderWidth: 1,
-            borderColor: theme.border,
-            borderRadius: 10,
-            paddingVertical: 10,
-          }}
-        >
-          <Ionicons name="chevron-back" size={16} color={theme.text} />
-          <Text style={{ color: theme.text, fontWeight: "700" }}>Previous</Text>
-        </Pressable>
-
-        <Pressable
-          onPress={onNextDay}
-          disabled={viewingToday}
-          style={{
-            flex: 1,
-            flexDirection: "row",
-            alignItems: "center",
-            justifyContent: "center",
-            gap: 6,
-            backgroundColor: theme.background,
-            borderWidth: 1,
-            borderColor: theme.border,
-            borderRadius: 10,
-            paddingVertical: 10,
-            opacity: viewingToday ? 0.45 : 1,
-          }}
-        >
-          <Text style={{ color: theme.text, fontWeight: "700" }}>Next</Text>
-          <Ionicons name="chevron-forward" size={16} color={theme.text} />
-        </Pressable>
-      </View>
-    </View>
+      <FreezeDayModal
+        visible={showFreezeModal}
+        date={selectedDate}
+        onFreeze={handleFreezeConfirm}
+        onCancel={handleFreezeCancel}
+      />
+    </>
   );
 }

--- a/components/FreezeDayModal.tsx
+++ b/components/FreezeDayModal.tsx
@@ -1,0 +1,184 @@
+import React from "react";
+import { Modal, View, Text, TextInput, Pressable, KeyboardAvoidingView, Platform } from "react-native";
+import { format } from "date-fns";
+import { useTheme } from "../contexts/ThemeContext";
+import { haptics } from "../utils/haptics";
+
+interface FreezeDayModalProps {
+  visible: boolean;
+  date: Date;
+  onFreeze: (reason: string) => void;
+  onCancel: () => void;
+}
+
+const MIN_REASON_LENGTH = 3;
+const MAX_REASON_LENGTH = 120;
+
+export default function FreezeDayModal({ visible, date, onFreeze, onCancel }: FreezeDayModalProps) {
+  const { theme } = useTheme();
+  const [reason, setReason] = React.useState("");
+
+  // Reset reason when modal opens
+  React.useEffect(() => {
+    if (visible) setReason("");
+  }, [visible]);
+
+  const trimmedReason = reason.trim();
+  const isValid = trimmedReason.length >= MIN_REASON_LENGTH;
+  const charsLeft = MAX_REASON_LENGTH - reason.length;
+
+  const handleFreeze = () => {
+    if (!isValid) {
+      void haptics.error();
+      return;
+    }
+    void haptics.success();
+    onFreeze(trimmedReason);
+  };
+
+  const handleCancel = () => {
+    void haptics.tap();
+    onCancel();
+  };
+
+  const dateLabel = format(date, "EEEE, MMM d");
+
+  return (
+    <Modal
+      animationType="fade"
+      transparent
+      visible={visible}
+      onRequestClose={handleCancel}
+    >
+      <KeyboardAvoidingView
+        behavior={Platform.OS === "ios" ? "padding" : "height"}
+        style={{ flex: 1 }}
+      >
+        <View
+          style={{
+            flex: 1,
+            justifyContent: "center",
+            padding: 24,
+            backgroundColor: "rgba(15, 23, 42, 0.45)",
+          }}
+        >
+          {/* Backdrop tap to dismiss */}
+          <Pressable
+            onPress={handleCancel}
+            style={{ position: "absolute", top: 0, right: 0, bottom: 0, left: 0 }}
+          />
+
+          <View
+            style={{
+              borderWidth: 1,
+              borderColor: theme.border,
+              borderRadius: 16,
+              padding: 20,
+              gap: 14,
+              backgroundColor: theme.surface,
+            }}
+          >
+            {/* Header */}
+            <View style={{ flexDirection: "row", alignItems: "center", gap: 10 }}>
+              <Text style={{ fontSize: 22 }}>❄️</Text>
+              <View style={{ flex: 1 }}>
+                <Text style={{ fontSize: 18, fontWeight: "800", color: theme.text }}>
+                  Freeze {dateLabel}
+                </Text>
+                <Text style={{ color: theme.textSecondary, fontSize: 13, marginTop: 2 }}>
+                  Frozen days won't break your streaks.
+                </Text>
+              </View>
+            </View>
+
+            {/* Reason input */}
+            <View style={{ gap: 6 }}>
+              <Text style={{ color: theme.text, fontWeight: "600", fontSize: 14 }}>
+                Why are you freezing this day?
+              </Text>
+              <TextInput
+                value={reason}
+                onChangeText={(text) => setReason(text.slice(0, MAX_REASON_LENGTH))}
+                placeholder="e.g., Family emergency, travel day, illness…"
+                placeholderTextColor={theme.textSecondary}
+                multiline
+                numberOfLines={3}
+                style={{
+                  borderWidth: 1,
+                  borderColor: charsLeft === 0 ? (theme.danger ?? "#ef4444") : isValid ? theme.primary : theme.border,
+                  borderRadius: 10,
+                  padding: 12,
+                  backgroundColor: theme.background,
+                  color: theme.text,
+                  fontSize: 15,
+                  minHeight: 80,
+                  textAlignVertical: "top",
+                }}
+                autoFocus
+              />
+              <View style={{ flexDirection: "row", justifyContent: "space-between" }}>
+                <Text style={{ color: theme.textSecondary, fontSize: 12 }}>
+                  {!isValid && trimmedReason.length > 0
+                    ? `At least ${MIN_REASON_LENGTH} characters required`
+                    : charsLeft === 0
+                    ? "Character limit reached"
+                    : "A reason helps you stay accountable."}
+                </Text>
+                <Text
+                  style={{
+                    color: charsLeft < 20 ? theme.danger ?? "#ef4444" : theme.textSecondary,
+                    fontSize: 12,
+                  }}
+                >
+                  {charsLeft}
+                </Text>
+              </View>
+            </View>
+
+            {/* Action buttons */}
+            <View style={{ flexDirection: "row", gap: 10, marginTop: 4 }}>
+              <Pressable
+                onPress={handleCancel}
+                style={{
+                  flex: 1,
+                  backgroundColor: theme.background,
+                  borderWidth: 1,
+                  borderColor: theme.border,
+                  padding: 12,
+                  borderRadius: 10,
+                  alignItems: "center",
+                }}
+              >
+                <Text style={{ color: theme.textSecondary, fontWeight: "600" }}>Cancel</Text>
+              </Pressable>
+              <Pressable
+                onPress={handleFreeze}
+                disabled={!isValid}
+                style={{
+                  flex: 1,
+                  backgroundColor: isValid ? theme.primary : theme.border,
+                  padding: 12,
+                  borderRadius: 10,
+                  alignItems: "center",
+                  flexDirection: "row",
+                  justifyContent: "center",
+                  gap: 6,
+                }}
+              >
+                <Text style={{ fontSize: 16 }}>❄️</Text>
+                <Text
+                  style={{
+                    color: isValid ? "white" : theme.textSecondary,
+                    fontWeight: "700",
+                  }}
+                >
+                  Freeze Day
+                </Text>
+              </Pressable>
+            </View>
+          </View>
+        </View>
+      </KeyboardAvoidingView>
+    </Modal>
+  );
+}

--- a/components/Heatmap.tsx
+++ b/components/Heatmap.tsx
@@ -1,6 +1,6 @@
 import React, { useRef, useEffect } from "react";
 import { View, ScrollView, Text } from "react-native";
-import Svg, { Rect, Circle } from "react-native-svg";
+import Svg, { Rect, Circle, Text as SvgText } from "react-native-svg";
 import { addDays, format, subDays, startOfMonth, isSameMonth, startOfWeek } from "date-fns";
 import { useTheme } from "../contexts/ThemeContext";
 
@@ -9,9 +9,10 @@ interface HMProps {
   values: Record<string, number>;      // yyyy-MM-dd -> count
   referenceDate?: Date;
   valueMode?: "count" | "ratio";
+  frozenDateKeys?: Set<string>;        // yyyy-MM-dd keys for frozen days
 }
 
-export default function Heatmap({ startOffsetDays = 120, values, referenceDate = new Date(), valueMode = "count" }: HMProps) {
+export default function Heatmap({ startOffsetDays = 120, values, referenceDate = new Date(), valueMode = "count", frozenDateKeys }: HMProps) {
   const scrollViewRef = useRef<ScrollView>(null);
   const { theme, isDark } = useTheme();
   const focusDate = referenceDate;
@@ -141,6 +142,8 @@ export default function Heatmap({ startOffsetDays = 120, values, referenceDate =
               const n = values[d] || 0;
               const isFocusDate = d === format(focusDate, "yyyy-MM-dd");
               
+              const isFrozen = frozenDateKeys ? frozenDateKeys.has(d) : false;
+
               return (
                 <React.Fragment key={d}>
                   <Rect 
@@ -149,17 +152,28 @@ export default function Heatmap({ startOffsetDays = 120, values, referenceDate =
                     width={cell} 
                     height={cell} 
                     rx={3} 
-                    fill={scale(n)}
-                    stroke={isFocusDate ? theme.primary : "transparent"}
-                    strokeWidth={isFocusDate ? 2 : 0}
+                    fill={isFrozen ? (isDark ? "#1e3a5f" : "#bfdbfe") : scale(n)}
+                    stroke={isFocusDate ? theme.primary : isFrozen ? (isDark ? "#60a5fa" : "#60a5fa") : "transparent"}
+                    strokeWidth={isFocusDate ? 2 : isFrozen ? 1 : 0}
                   />
-                  {isFocusDate && (
+                  {isFocusDate && !isFrozen && (
                     <Circle
                       cx={x + cell/2}
                       cy={y + cell/2}
                       r={2}
                       fill={theme.primary}
                     />
+                  )}
+                  {isFrozen && (
+                    <SvgText
+                      x={x + cell / 2}
+                      y={y + cell / 2 + 4}
+                      fontSize={9}
+                      textAnchor="middle"
+                      fill={isDark ? "#93c5fd" : "#1d4ed8"}
+                    >
+                      ❄
+                    </SvgText>
                   )}
                 </React.Fragment>
               );

--- a/components/HomeScreen.tsx
+++ b/components/HomeScreen.tsx
@@ -34,6 +34,10 @@ export default function HomeScreen({ navigation, onAccountDeleted }: HomeScreenP
   const setGoals = useStore((s) => s.setGoals);
   const setAccount = useStore((s) => s.setAccount);
   const setCloudSyncEnabled = useStore((s) => s.setCloudSyncEnabled);
+  const freezeDay = useStore((s) => s.freezeDay);
+  const unfreezeDay = useStore((s) => s.unfreezeDay);
+  const isDayFrozen = useStore((s) => s.isDayFrozen);
+  const getFreezeReason = useStore((s) => s.getFreezeReason);
   const currentMode = getCurrentMode();
   const { theme, isDark, toggleTheme } = useTheme();
   const [settingsVisible, setSettingsVisible] = useState(false);
@@ -42,6 +46,20 @@ export default function HomeScreen({ navigation, onAccountDeleted }: HomeScreenP
   const [radarMode, setRadarMode] = useState<RadarChartMode>("current");
   const isDevToolsVisible = currentMode === "DEV";
   const canReorderGoals = goals.length > 1;
+
+  // Check if any recurring tasks have completions on the selected date
+  const hasCompletionsOnDate = React.useMemo(() => {
+    const dateKey = selectedDate.toISOString().split("T")[0];
+    return goals.some((goal) =>
+      goal.tasks.some(
+        (task) =>
+          task.frequency !== "once" &&
+          task.completions.some(
+            (date) => date.toISOString().split("T")[0] === dateKey
+          )
+      )
+    );
+  }, [goals, selectedDate]);
 
   useLayoutEffect(() => {
     navigation.setOptions({
@@ -173,6 +191,9 @@ export default function HomeScreen({ navigation, onAccountDeleted }: HomeScreenP
         <View style={{ padding: 16, gap: 12 }}>
           <DateContextCard
             selectedDate={selectedDate}
+            isFrozen={isDayFrozen(selectedDate)}
+            freezeReason={getFreezeReason(selectedDate)}
+            hasCompletions={hasCompletionsOnDate}
             onPress={() => {
               void haptics.tap();
               setCalendarVisible(true);
@@ -189,6 +210,12 @@ export default function HomeScreen({ navigation, onAccountDeleted }: HomeScreenP
 
               void haptics.tap();
               setSelectedDate(getNextTrackingDate(selectedDate));
+            }}
+            onFreezeDay={(reason) => {
+              freezeDay(selectedDate, reason);
+            }}
+            onUnfreezeDay={() => {
+              unfreezeDay(selectedDate);
             }}
           />
 

--- a/components/InstructionsScreen.tsx
+++ b/components/InstructionsScreen.tsx
@@ -62,7 +62,16 @@ export default function InstructionsScreen() {
           </Text>
         </InfoSection>
 
-        <InfoSection title="6. Start with your own goals">
+        <InfoSection title="6. Freeze a day when life gets in the way">
+          <Text style={{ color: theme.textSecondary, lineHeight: 22 }}>
+            On the date card, tap ❄️ Freeze This Day to pause tracking for that day. You must enter a reason, this keeps you accountable while protecting your streaks.
+          </Text>
+          <Text style={{ color: theme.textSecondary, lineHeight: 22 }}>
+            Frozen days are shown with a snowflake on heatmaps and in the date card. They do not count toward your streak, but they also do not break it. Tap the frozen pill to unfreeze at any time.
+          </Text>
+        </InfoSection>
+
+        <InfoSection title="7. Start with your own goals">
           <Text style={{ color: theme.textSecondary, lineHeight: 22 }}>
             After onboarding and account setup, OnTrack starts empty. Add your own goals and tasks to build a consistency history that reflects your real routine.
           </Text>

--- a/components/OverviewScreen.tsx
+++ b/components/OverviewScreen.tsx
@@ -29,6 +29,7 @@ export default function OverviewScreen({ navigation, route }: OverviewProps) {
   const { goalId } = route.params;
   const goal = useStore((s) => s.goals.find((g) => g.id === goalId)!);
   const selectedDate = useStore((s) => s.selectedDate);
+  const frozenDays = useStore((s) => s.frozenDays);
   const { theme } = useTheme();
   const [viewMode, setViewMode] = React.useState<"summary" | "tasks">("tasks");
 
@@ -76,6 +77,7 @@ export default function OverviewScreen({ navigation, route }: OverviewProps) {
   const onceTaskHeatmapData = getHeatmapData(onceTasks.flatMap((task) => task.completions));
   const onceTaskCompletionCount = Object.values(onceTaskHeatmapData).reduce((sum, count) => sum + count, 0);
   const hasOnceTaskHistory = onceTaskCompletionCount > 0;
+  const frozenDateKeySet = new Set(frozenDays.map((fd) => fd.date));
 
   return (
     <SafeAreaView style={{ flex: 1, backgroundColor: theme.background }} edges={['bottom', 'left', 'right']}>
@@ -138,6 +140,7 @@ export default function OverviewScreen({ navigation, route }: OverviewProps) {
               values={recurringGoalSummaryHeatmapData}
               referenceDate={selectedDate}
               valueMode="ratio"
+              frozenDateKeys={frozenDateKeySet}
             />
 
             <View style={{ gap: 6 }}>
@@ -219,7 +222,7 @@ export default function OverviewScreen({ navigation, route }: OverviewProps) {
                   
                   {/* Fire Streak Indicator - Always Show */}
                   {(() => {
-                    const streak = getGoalStreak(task);
+                    const streak = getGoalStreak(task, frozenDays);
                     const hasStreak = streak > 0;
                     const customProgress = task.frequency === "custom" && task.customFrequency
                       ? getCustomFrequencyProgress(task, new Date())
@@ -317,6 +320,7 @@ export default function OverviewScreen({ navigation, route }: OverviewProps) {
                 startOffsetDays={180} 
                 values={getHeatmapData(task.completions)}
                 referenceDate={selectedDate}
+                frozenDateKeys={frozenDateKeySet}
               />
             </View>
             {index < recurringTasks.length - 1 && <View style={{ height: 16 }} />}

--- a/overviewScreen.test.tsx
+++ b/overviewScreen.test.tsx
@@ -47,6 +47,7 @@ jest.mock('./contexts/ThemeContext', () => ({
 
 const mockState = {
   selectedDate: new Date('2026-05-06T12:00:00.000Z'),
+  frozenDays: [] as Array<{ date: string; reason: string; createdAt: number }>,
   goals: [
     {
       id: 'goal-1',

--- a/package-lock.json
+++ b/package-lock.json
@@ -87,7 +87,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1469,7 +1468,6 @@
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
       "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -2799,7 +2797,6 @@
       "resolved": "https://registry.npmjs.org/@react-navigation/native/-/native-7.2.2.tgz",
       "integrity": "sha512-kem1Ko2BcbAjmbQIv66dNmr6EtfDut3QU0qjsVhMnLLhktwyXb6FzZYp8gTrUb6AvkAbaJoi+BF5Pl55pAUa5w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@react-navigation/core": "^7.17.2",
         "escape-string-regexp": "^4.0.0",
@@ -3453,7 +3450,6 @@
       "integrity": "sha512-Qec1E3mhALmaspIrhWt9jkQMNdw6bReVu64mjvhbhq2NFPftLPVr+l1SZgmw/66WwBNpDh7ao5AT6gF5v41PFA==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -4280,7 +4276,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -5454,7 +5449,6 @@
       "resolved": "https://registry.npmjs.org/expo/-/expo-54.0.33.tgz",
       "integrity": "sha512-3yOEfAKqo+gqHcV8vKcnq0uA5zxlohnhA3fu4G43likN8ct5ZZ3LjAh9wDdKteEkoad3tFPvwxmXW711S5OHUw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.20.0",
         "@expo/cli": "54.0.23",
@@ -5521,7 +5515,6 @@
       "resolved": "https://registry.npmjs.org/expo-font/-/expo-font-14.0.11.tgz",
       "integrity": "sha512-ga0q61ny4s/kr4k8JX9hVH69exVSIfcIc19+qZ7gt71Mqtm7xy2c6kwsPTCyhBW2Ro5yXTT8EaZOpuRi35rHbg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fontfaceobserver": "^2.1.0"
       },
@@ -6750,7 +6743,6 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -9658,7 +9650,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
       "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9696,7 +9687,6 @@
       "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.81.5.tgz",
       "integrity": "sha512-1w+/oSjEXZjMqsIvmkCRsOc8UBYv163bTWKTI8+1mxztvQPhCRYGTvZ/PL1w16xXHneIj/SLGfxWg2GWN2uexw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/create-cache-key-function": "^29.7.0",
         "@react-native/assets-registry": "0.81.5",
@@ -9774,7 +9764,6 @@
       "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-2.28.0.tgz",
       "integrity": "sha512-0msfJ1vRxXKVgTgvL+1ZOoYw3/0z1R+Ked0+udoJhyplC2jbVKIJ8Z1bzWdpQRCV3QcQ87Op0zJVE5DhKK2A0A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@egjs/hammerjs": "^2.0.17",
         "hoist-non-react-statics": "^3.3.0",
@@ -9800,7 +9789,6 @@
       "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-4.1.7.tgz",
       "integrity": "sha512-Q4H6xA3Tn7QL0/E/KjI86I1KK4tcf+ErRE04LH34Etka2oVQhW6oXQ+Q8ZcDCVxiWp5vgbBH6XcH8BOo4w/Rhg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "react-native-is-edge-to-edge": "^1.2.1",
         "semver": "^7.7.2"
@@ -9828,7 +9816,6 @@
       "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-5.6.2.tgz",
       "integrity": "sha512-4XGqMNj5qjUTYywJqpdWZ9IG8jgkS3h06sfVjfw5yZQZfWnRFXczi0GnYyFyCc2EBps/qFmoCH8fez//WumdVg==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
@@ -9839,7 +9826,6 @@
       "resolved": "https://registry.npmjs.org/react-native-screens/-/react-native-screens-4.16.0.tgz",
       "integrity": "sha512-yIAyh7F/9uWkOzCi1/2FqvNvK6Wb9Y1+Kzn16SuGfN9YFJDTbwlzGRvePCNTOX0recpLQF3kc2FmvMUhyTCH1Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "react-freeze": "^1.0.0",
         "react-native-is-edge-to-edge": "^1.2.1",
@@ -9870,7 +9856,6 @@
       "resolved": "https://registry.npmjs.org/react-native-worklets/-/react-native-worklets-0.5.1.tgz",
       "integrity": "sha512-lJG6Uk9YuojjEX/tQrCbcbmpdLCSFxDK1rJlkDhgqkVi1KZzG7cdcBFQRqyNOOzR9Y0CXNuldmtWTGOyM0k0+w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/plugin-transform-arrow-functions": "^7.0.0-0",
         "@babel/plugin-transform-class-properties": "^7.0.0-0",
@@ -10003,7 +9988,6 @@
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
       "integrity": "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10014,7 +9998,6 @@
       "integrity": "sha512-jXkSl3CpvPYEF+p/eGDLB4sPoDX8pKkYvRl9+rR8HxLY0X04vW7hCm1/0zHoUSjPZ3bDa+wXWNTDVIw/R8aDVw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "react-is": "^19.1.0",
         "scheduler": "^0.26.0"
@@ -11055,7 +11038,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -11155,7 +11137,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/store.ts
+++ b/store.ts
@@ -1,8 +1,8 @@
 import { create } from "zustand";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { persist, createJSONStorage } from "zustand/middleware";
-import { Goal, Frequency, CustomFrequency, Task, UserAccount } from "./types";
-import { format, startOfDay, startOfWeek, endOfWeek, startOfMonth, endOfMonth, isWithinInterval, differenceInCalendarDays } from "date-fns";
+import { Goal, Frequency, CustomFrequency, Task, UserAccount, FreezeDay } from "./types";
+import { format, startOfDay, startOfWeek, endOfWeek, startOfMonth, endOfMonth, isWithinInterval, differenceInCalendarDays, addDays } from "date-fns";
 import { normalizeAccountDraft } from "./account";
 
 // Date utility functions
@@ -166,19 +166,35 @@ export const getCustomFrequencyAlert = (task: Task, referenceDate: Date = new Da
 };
 
 // Helper to calculate streak for any goal type
-export const getGoalStreak = (task: Task): number => {
+// frozenDays: pass the store's frozenDays array so frozen dates are skipped (not broken)
+export const getGoalStreak = (task: Task, frozenDays: FreezeDay[] = []): number => {
   let streak = 0;
   let currentDate = new Date();
-  
+
+  // Build a Set of frozen date keys for O(1) lookup
+  const frozenDateKeys = new Set(frozenDays.map((fd) => fd.date));
+  const isDateKeyFrozen = (dateKey: string) => frozenDateKeys.has(dateKey);
+
   if (task.frequency === "custom" && task.customFrequency) {
     // For custom frequencies, check period achievements
     const { type } = task.customFrequency;
     
-    // First check if current period is achieved
+    // First check if current period is achieved (with freeze-adjusted target)
     let currentProgress = getCustomFrequencyProgress(task, currentDate);
-    
+    let frozenInCurrentPeriod = 0;
+    if (currentProgress.periodStart && currentProgress.periodEnd) {
+      let d = startOfDay(currentProgress.periodStart);
+      while (d <= currentProgress.periodEnd) {
+        if (isDateKeyFrozen(format(d, "yyyy-MM-dd"))) frozenInCurrentPeriod++;
+        d = addDays(d, 1);
+      }
+    }
+    const minTarget = Math.max(1, Math.ceil(currentProgress.target * 0.5));
+    const adjustedTarget = Math.max(minTarget, currentProgress.target - frozenInCurrentPeriod);
+    const currentAchieved = currentProgress.completed >= adjustedTarget;
+
     // If current period is achieved, start counting from it
-    if (currentProgress.achieved) {
+    if (currentAchieved) {
       streak++;
       // Move to previous period
       if (type === "weekly") {
@@ -198,8 +214,23 @@ export const getGoalStreak = (task: Task): number => {
     // Now count consecutive achieved periods going backwards
     while (true) {
       const progress = getCustomFrequencyProgress(task, currentDate);
-      
-      if (progress.achieved) {
+
+      // Count frozen days in this period to reduce effective target
+      let frozenInPeriod = 0;
+      if (progress.periodStart && progress.periodEnd) {
+        let d = startOfDay(progress.periodStart);
+        while (d <= progress.periodEnd) {
+          if (isDateKeyFrozen(format(d, "yyyy-MM-dd"))) frozenInPeriod++;
+          d = addDays(d, 1);
+        }
+      }
+      // Require at least 50% of original target (rounded up) to prevent
+      // streaks from continuing with minimal effort when many days are frozen
+      const minTarget = Math.max(1, Math.ceil(progress.target * 0.5));
+      const adjustedTarget = Math.max(minTarget, progress.target - frozenInPeriod);
+      const periodAchieved = progress.completed >= adjustedTarget;
+
+      if (periodAchieved) {
         streak++;
         // Move to previous period
         if (type === "weekly") {
@@ -215,7 +246,7 @@ export const getGoalStreak = (task: Task): number => {
       if (streak > 104) break;
     }
   } else if (task.frequency === "daily") {
-    // For daily tasks, check consecutive days
+    // For daily tasks, check consecutive days; frozen days are skipped (neutral)
     while (true) {
       const dateStr = format(currentDate, "yyyy-MM-dd");
       const hasCompletion = task.completions.some(date => 
@@ -226,6 +257,9 @@ export const getGoalStreak = (task: Task): number => {
         streak++;
         // Move to previous day
         currentDate.setDate(currentDate.getDate() - 1);
+      } else if (isDateKeyFrozen(dateStr)) {
+        // Frozen day: skip without incrementing or breaking
+        currentDate.setDate(currentDate.getDate() - 1);
       } else {
         break; // Streak broken
       }
@@ -235,6 +269,7 @@ export const getGoalStreak = (task: Task): number => {
     }
   } else if (task.frequency === "weekly") {
     // For weekly tasks, check consecutive weeks
+    // A week is "frozen" if it has no completions but all 7 days are frozen
     while (true) {
       const weekStart = startOfWeek(currentDate, { weekStartsOn: 0 }); // Sunday
       const weekEnd = endOfWeek(currentDate, { weekStartsOn: 0 }); // Saturday
@@ -242,13 +277,28 @@ export const getGoalStreak = (task: Task): number => {
       const hasCompletionThisWeek = task.completions.some(date => 
         isWithinInterval(date, { start: weekStart, end: weekEnd })
       );
-      
+
       if (hasCompletionThisWeek) {
         streak++;
         // Move to previous week
         currentDate.setDate(currentDate.getDate() - 7);
       } else {
-        break; // Streak broken
+        // Check if the entire week is frozen (all 7 days)
+        let allFrozen = true;
+        let d = startOfDay(weekStart);
+        while (d <= weekEnd) {
+          if (!isDateKeyFrozen(format(d, "yyyy-MM-dd"))) {
+            allFrozen = false;
+            break;
+          }
+          d = addDays(d, 1);
+        }
+        if (allFrozen) {
+          // Skip this week without incrementing or breaking
+          currentDate.setDate(currentDate.getDate() - 7);
+        } else {
+          break; // Streak broken
+        }
       }
       
       // Safety check - don't go back more than 104 weeks (2 years)
@@ -594,6 +644,7 @@ interface State {
     cloudSyncEnabled: boolean;
     syncRevision: number;
     lastSyncedRevision: number;
+    frozenDays: FreezeDay[];
     setGoals: (goals: Goal[]) => void;
     setCloudSyncEnabled: (enabled: boolean) => void;
     markGoalsSynced: (revision: number) => void;
@@ -606,6 +657,10 @@ interface State {
     reorderTasks: (goalId: string, taskIdsInOrder: string[]) => void;
     deleteTask: (goalId: string, taskId: string) => void;
     toggleTaskCompletion: (goalId: string, taskId: string, date?: Date) => void;
+    freezeDay: (date: Date, reason: string) => boolean;
+    unfreezeDay: (date: Date) => void;
+    isDayFrozen: (date: Date) => boolean;
+    getFreezeReason: (date: Date) => string | undefined;
     completionsByDate: () => Record<string, number>;
     deleteGoal: (goalId: string) => void;
     resetAppData: () => void;
@@ -643,6 +698,7 @@ export const useStore = create<State>()(
             cloudSyncEnabled: false,
             syncRevision: 0,
             lastSyncedRevision: 0,
+            frozenDays: [],
 
             /**
              * This setter is the bridge between remote reads and the existing
@@ -827,6 +883,43 @@ export const useStore = create<State>()(
                         s.syncRevision
                     );
                 }),
+            /**
+             * Freeze a day with a required reason. Returns true on success,
+             * false if the reason is empty/whitespace.
+             * Upserting by date key means re-freezing the same day updates the reason.
+             */
+            freezeDay: (date, reason) => {
+                const trimmedReason = reason.trim();
+                if (!trimmedReason) return false;
+                const dateKey = dateToKey(date);
+                set((s) => ({
+                    frozenDays: [
+                        ...s.frozenDays.filter((fd) => fd.date !== dateKey),
+                        { date: dateKey, reason: trimmedReason, createdAt: Date.now() },
+                    ],
+                    syncRevision: s.syncRevision + 1,
+                }));
+                return true;
+            },
+
+            unfreezeDay: (date) => {
+                const dateKey = dateToKey(date);
+                set((s) => ({
+                    frozenDays: s.frozenDays.filter((fd) => fd.date !== dateKey),
+                    syncRevision: s.syncRevision + 1,
+                }));
+            },
+
+            isDayFrozen: (date) => {
+                const dateKey = dateToKey(date);
+                return get().frozenDays.some((fd) => fd.date === dateKey);
+            },
+
+            getFreezeReason: (date) => {
+                const dateKey = dateToKey(date);
+                return get().frozenDays.find((fd) => fd.date === dateKey)?.reason;
+            },
+
             completionsByDate: () => {
                 const map: Record<string, number> = {};
                 for (const g of get().goals) {

--- a/tests/store.test.ts
+++ b/tests/store.test.ts
@@ -1,5 +1,6 @@
-import { getCustomFrequencyProgress, getGoalProgress, getSampleGoals, isOnceTaskCompletedOnDate, useStore } from '../store';
-import { Goal, Task } from '../types';
+import { getCustomFrequencyProgress, getGoalProgress, getGoalStreak, getSampleGoals, isOnceTaskCompletedOnDate, useStore } from '../store';
+import { FreezeDay, Goal, Task } from '../types';
+import { format, startOfWeek } from 'date-fns';
 
 describe('getCustomFrequencyProgress', () => {
   it('counts weekly custom completions inside the active week', () => {
@@ -293,5 +294,262 @@ describe('updateGoal', () => {
     useStore.getState().updateGoal('goal-2', { target: null });
 
     expect(useStore.getState().goals[0].target).toBeUndefined();
+  });
+});
+
+// ─── Freeze Days ─────────────────────────────────────────────────────────────
+
+describe('freeze day store actions', () => {
+  const originalState = useStore.getState();
+
+  afterEach(() => {
+    useStore.setState(originalState, true);
+  });
+
+  it('freezeDay persists a freeze with the given reason', () => {
+    const date = new Date('2026-05-10T12:00:00.000Z');
+    const result = useStore.getState().freezeDay(date, 'Family emergency');
+
+    expect(result).toBe(true);
+    const frozen = useStore.getState().frozenDays;
+    expect(frozen).toHaveLength(1);
+    expect(frozen[0].date).toBe('2026-05-10');
+    expect(frozen[0].reason).toBe('Family emergency');
+  });
+
+  it('freezeDay rejects empty or whitespace-only reasons', () => {
+    const date = new Date('2026-05-10T12:00:00.000Z');
+    const result = useStore.getState().freezeDay(date, '   ');
+
+    expect(result).toBe(false);
+    expect(useStore.getState().frozenDays).toHaveLength(0);
+  });
+
+  it('unfreezeDay removes the freeze for the given date', () => {
+    const date = new Date('2026-05-10T12:00:00.000Z');
+    useStore.getState().freezeDay(date, 'Travel day');
+    useStore.getState().unfreezeDay(date);
+
+    expect(useStore.getState().frozenDays).toHaveLength(0);
+  });
+
+  it('isDayFrozen returns true for a frozen date and false otherwise', () => {
+    const date = new Date('2026-05-10T12:00:00.000Z');
+    useStore.getState().freezeDay(date, 'Illness');
+
+    expect(useStore.getState().isDayFrozen(date)).toBe(true);
+    expect(useStore.getState().isDayFrozen(new Date('2026-05-11T12:00:00.000Z'))).toBe(false);
+  });
+
+  it('getFreezeReason returns the reason for a frozen date', () => {
+    const date = new Date('2026-05-10T12:00:00.000Z');
+    useStore.getState().freezeDay(date, 'Doctor appointment');
+
+    expect(useStore.getState().getFreezeReason(date)).toBe('Doctor appointment');
+    expect(useStore.getState().getFreezeReason(new Date('2026-05-11T12:00:00.000Z'))).toBeUndefined();
+  });
+
+  it('re-freezing the same day updates the reason (upsert)', () => {
+    const date = new Date('2026-05-10T12:00:00.000Z');
+    useStore.getState().freezeDay(date, 'First reason');
+    useStore.getState().freezeDay(date, 'Updated reason');
+
+    const frozen = useStore.getState().frozenDays;
+    expect(frozen).toHaveLength(1);
+    expect(frozen[0].reason).toBe('Updated reason');
+  });
+});
+
+// ─── getGoalStreak with frozen days ──────────────────────────────────────────
+
+// Helper: get a local date key (yyyy-MM-dd) for N days ago, matching how
+// getGoalStreak uses format(currentDate, "yyyy-MM-dd") with local time.
+function localDateKey(daysAgo: number): string {
+  const d = new Date();
+  d.setDate(d.getDate() - daysAgo);
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}
+
+function localDate(daysAgo: number): Date {
+  const d = new Date();
+  d.setHours(12, 0, 0, 0);
+  d.setDate(d.getDate() - daysAgo);
+  return d;
+}
+
+describe('getGoalStreak with frozen days', () => {
+  it('daily streak: frozen gap day does not break the streak', () => {
+    // today=0, yesterday=1, twoDaysAgo=2 (frozen), threeDaysAgo=3
+    const task: Task = {
+      id: 'streak-daily-relative',
+      title: 'Meditate',
+      frequency: 'daily',
+      completions: [
+        localDate(0),  // today
+        localDate(1),  // yesterday
+        // localDate(2) is the gap (frozen)
+        localDate(3),  // 3 days ago
+      ],
+    };
+    const frozenDays: FreezeDay[] = [
+      { date: localDateKey(2), reason: 'Travel', createdAt: Date.now() },
+    ];
+
+    // Without freeze: streak = 2 (today + yesterday, then gap breaks)
+    expect(getGoalStreak(task, [])).toBe(2);
+    // With freeze: streak = 3 (today, yesterday, frozen gap skipped without incrementing, 3 days ago)
+    // Frozen days are neutral — they don't break the chain but also don't count toward the streak.
+    expect(getGoalStreak(task, frozenDays)).toBe(3);
+  });
+
+  it('daily streak: non-frozen gap still breaks the streak', () => {
+    const task: Task = {
+      id: 'streak-daily-break',
+      title: 'Run',
+      frequency: 'daily',
+      completions: [
+        localDate(0),  // today
+        localDate(1),  // yesterday
+        // localDate(2) is NOT frozen and NOT completed — streak breaks here
+        localDate(3),  // 3 days ago
+      ],
+    };
+
+    // No freeze: streak = 2 (today + yesterday, then gap breaks)
+    expect(getGoalStreak(task, [])).toBe(2);
+    // Even with an unrelated freeze, the gap still breaks
+    const unrelatedFreeze: FreezeDay[] = [
+      { date: '2020-01-01', reason: 'Old freeze', createdAt: Date.now() },
+    ];
+    expect(getGoalStreak(task, unrelatedFreeze)).toBe(2);
+  });
+
+  it('weekly streak: all 7 days frozen in a gap week bridges to an older completed week', () => {
+    // This week: has completion → streak=1
+    // Last week: has completion → streak=2
+    // Two weeks ago: all 7 days frozen (no completion) → skip, streak stays 2
+    // Three weeks ago: has completion → streak=3
+    // Four weeks ago: no completion, not frozen → break
+    const thisWeekDate = new Date();
+    const lastWeekDate = new Date();
+    lastWeekDate.setDate(lastWeekDate.getDate() - 7);
+    const threeWeeksAgoDate = new Date();
+    threeWeeksAgoDate.setDate(threeWeeksAgoDate.getDate() - 21);
+
+    const task: Task = {
+      id: 'streak-weekly-frozen',
+      title: 'Clean house',
+      frequency: 'weekly',
+      completions: [
+        thisWeekDate,
+        lastWeekDate,
+        threeWeeksAgoDate,
+      ],
+    };
+
+    // Freeze all 7 days of the week two weeks ago (the gap week)
+    const frozenDays: FreezeDay[] = [];
+    const twoWeeksAgo = new Date();
+    twoWeeksAgo.setDate(twoWeeksAgo.getDate() - 14);
+    const weekStart = startOfWeek(twoWeeksAgo, { weekStartsOn: 0 });
+    for (let i = 0; i < 7; i++) {
+      const d = new Date(weekStart);
+      d.setDate(d.getDate() + i);
+      frozenDays.push({ date: format(d, 'yyyy-MM-dd'), reason: 'Vacation', createdAt: Date.now() });
+    }
+
+    // Without freeze: streak = 2 (this week + last week, then gap breaks)
+    expect(getGoalStreak(task, [])).toBe(2);
+    // With all 7 days frozen in the gap week: streak = 3 (bridges to three weeks ago)
+    expect(getGoalStreak(task, frozenDays)).toBe(3);
+  });
+
+  it('weekly streak: partially frozen week still breaks the streak', () => {
+    const thisWeekDate = new Date();
+    const lastWeekDate = new Date();
+    lastWeekDate.setDate(lastWeekDate.getDate() - 7);
+    const threeWeeksAgoDate = new Date();
+    threeWeeksAgoDate.setDate(threeWeeksAgoDate.getDate() - 21);
+
+    const task: Task = {
+      id: 'streak-weekly-partial-freeze',
+      title: 'Clean house',
+      frequency: 'weekly',
+      completions: [
+        thisWeekDate,
+        lastWeekDate,
+        threeWeeksAgoDate,
+      ],
+    };
+
+    // Freeze only 3 days of the week two weeks ago (not all 7)
+    const frozenDays: FreezeDay[] = [];
+    const twoWeeksAgo = new Date();
+    twoWeeksAgo.setDate(twoWeeksAgo.getDate() - 14);
+    const weekStart = startOfWeek(twoWeeksAgo, { weekStartsOn: 0 });
+    for (let i = 0; i < 3; i++) {
+      const d = new Date(weekStart);
+      d.setDate(d.getDate() + i);
+      frozenDays.push({ date: format(d, 'yyyy-MM-dd'), reason: 'Sick', createdAt: Date.now() });
+    }
+
+    // Streak should still be 2 because the gap week is not fully frozen
+    expect(getGoalStreak(task, frozenDays)).toBe(2);
+  });
+
+  it('custom weekly streak: freeze-adjusted target allows streak to continue', () => {
+    // Task requires 3 times per week
+    // This week: 3 completions → achieved → streak=1
+    // Last week: 2 completions + 1 frozen → adjusted target = max(2, 3-1) = 2 → achieved → streak=2
+    // Two weeks ago: 1 completion + 2 frozen → adjusted target = max(2, 3-2) = 2 → NOT achieved (1 < 2) → break
+    const thisWeekDate = new Date();
+    const lastWeekDate = new Date();
+    lastWeekDate.setDate(lastWeekDate.getDate() - 7);
+    const twoWeeksAgoDate = new Date();
+    twoWeeksAgoDate.setDate(twoWeeksAgoDate.getDate() - 14);
+
+    const task: Task = {
+      id: 'streak-custom-weekly',
+      title: 'Go to gym',
+      frequency: 'custom',
+      customFrequency: { type: 'weekly', target: 3 },
+      completions: [
+        // This week: 3 completions
+        thisWeekDate,
+        new Date(thisWeekDate.getFullYear(), thisWeekDate.getMonth(), thisWeekDate.getDate() - 1),
+        new Date(thisWeekDate.getFullYear(), thisWeekDate.getMonth(), thisWeekDate.getDate() - 2),
+        // Last week: 2 completions
+        lastWeekDate,
+        new Date(lastWeekDate.getFullYear(), lastWeekDate.getMonth(), lastWeekDate.getDate() - 1),
+      ],
+    };
+
+    // Freeze 1 day in last week and 2 days in two weeks ago
+    const frozenDays: FreezeDay[] = [];
+    // Last week: freeze 1 day (so adjusted target = max(2, 3-1) = 2, completed = 2 → achieved)
+    const lastWeekFreeze = new Date(lastWeekDate);
+    lastWeekFreeze.setDate(lastWeekFreeze.getDate() + 2);
+    frozenDays.push({ date: format(lastWeekFreeze, 'yyyy-MM-dd'), reason: 'Travel', createdAt: Date.now() });
+
+    // Two weeks ago: freeze 2 days, 1 completion (adjusted target = max(2, 3-2) = 2, completed = 1 → NOT achieved)
+    const weekStart = startOfWeek(twoWeeksAgoDate, { weekStartsOn: 0 });
+    for (let i = 0; i < 2; i++) {
+      const d = new Date(weekStart);
+      d.setDate(d.getDate() + i);
+      frozenDays.push({ date: format(d, 'yyyy-MM-dd'), reason: 'Sick', createdAt: Date.now() });
+    }
+    // Add 1 completion in that week
+    const completionDate = new Date(weekStart);
+    completionDate.setDate(completionDate.getDate() + 2);
+    task.completions.push(completionDate);
+
+    // With freeze adjustment: streak = 2 (this week + last week, then two weeks ago fails)
+    expect(getGoalStreak(task, frozenDays)).toBe(2);
+
+    // Without freezes: last week only has 2/3 → NOT achieved, so streak = 1
+    expect(getGoalStreak(task, [])).toBe(1);
   });
 });

--- a/types.ts
+++ b/types.ts
@@ -1,5 +1,11 @@
 export type Frequency = "once" | "daily" | "weekly" | "custom";
 
+export interface FreezeDay {
+  date: string;      // "yyyy-MM-dd" canonical day key
+  reason: string;    // required, trimmed, non-empty
+  createdAt: number; // Date.now() at freeze time
+}
+
 export interface CustomFrequency {
   type: "weekly" | "monthly";
   target: number; // e.g., 3 times per week, 5 times per month


### PR DESCRIPTION
## Summary

Add a Duolingo-style 'Streak Freeze' mechanic so users can protect their consistency streaks on days they were unable to work toward goals.

## Changes

### Data Model
- Add `FreezeDay` interface to `types.ts` (date, reason, createdAt)
- Add `frozenDays` state + actions to Zustand store: `freezeDay`, `unfreezeDay`, `isDayFrozen`, `getFreezeReason`

### Streak Calculation
- Update `getGoalStreak()` to accept `frozenDays` and skip frozen days without breaking the chain
- **Daily**: frozen days are skipped (neutral — no increment, no break)
- **Weekly**: a week with all 7 days frozen is skipped without breaking
- **Custom**: freeze-adjusted target reduces effective target proportionally (clamped to 50% minimum)

### UI
- **FreezeDayModal**: new component with reason validation (3-120 chars)
- **DateContextCard**: freeze button appears only when no tasks completed that day; frozen pill shows with unfreeze option
- **Heatmap**: snowflake overlay on frozen day cells
- **Dark mode**: theme-aware frozen colors for all components

### Tests
- 9 new tests: freeze CRUD operations + daily/weekly/custom streak behavior with freezes
- All 62 tests pass

## Deferred (future tickets)
- Monthly freeze limit
- Friend approval flow
- Cloud sync of frozenDays

![image](https://github.com/user-attachments/assets/e1d63327-306e-42cd-9320-4103128c82fc)

![image](https://github.com/user-attachments/assets/30461eb9-6b1e-4d74-b62f-07856ff07ea6)

![image](https://github.com/user-attachments/assets/e3ab3814-bbba-4237-a50e-5dffd6890555)