### PR TITLE
Persist consistency view selections

### DIFF
--- a/components/HomeScreen.tsx
+++ b/components/HomeScreen.tsx
@@ -13,7 +13,6 @@ import DateContextCard from "./DateContextCard";
 import CalendarModal from "./CalendarModal";
 import { haptics } from "../utils/haptics";
 import { RootStackParamList } from "../navigation";
-import { RadarChartMode } from "./RadarChart";
 import { getNextTrackingDate, getPreviousTrackingDate } from "../lib/dateContext";
 import { deleteCurrentAccount } from "../lib/auth";
 import { ONBOARDING_STORAGE_KEY } from "../onboarding";
@@ -40,11 +39,12 @@ export default function HomeScreen({ navigation, onAccountDeleted }: HomeScreenP
   const isDayFrozen = useStore((s) => s.isDayFrozen);
   const getFreezeReason = useStore((s) => s.getFreezeReason);
   const currentMode = getCurrentMode();
+  const homeRadarMode = useStore((s) => s.homeRadarMode);
+  const setHomeRadarMode = useStore((s) => s.setHomeRadarMode);
   const { theme, isDark, toggleTheme } = useTheme();
   const [settingsVisible, setSettingsVisible] = useState(false);
   const [calendarVisible, setCalendarVisible] = useState(false);
   const [isReorderingGoals, setIsReorderingGoals] = useState(false);
-  const [radarMode, setRadarMode] = useState<RadarChartMode>("current");
   const activeGoals = React.useMemo(
     () => goals.filter((goal) => goal.completedAt === undefined),
     [goals]
@@ -243,7 +243,7 @@ export default function HomeScreen({ navigation, onAccountDeleted }: HomeScreenP
               <Pressable
                 key={option.key}
                 onPress={() => {
-                  setRadarMode(option.key);
+                  setHomeRadarMode(option.key);
                   void haptics.tap();
                 }}
                 style={{
@@ -251,11 +251,11 @@ export default function HomeScreen({ navigation, onAccountDeleted }: HomeScreenP
                   paddingVertical: 6,
                   borderRadius: 9999,
                   borderWidth: 1,
-                  borderColor: radarMode === option.key ? theme.primary : theme.border,
-                  backgroundColor: radarMode === option.key ? theme.primary + "20" : theme.surface,
+                  borderColor: homeRadarMode === option.key ? theme.primary : theme.border,
+                  backgroundColor: homeRadarMode === option.key ? theme.primary + "20" : theme.surface,
                 }}
               >
-                <Text style={{ color: radarMode === option.key ? theme.primary : theme.textSecondary, fontWeight: "600", fontSize: 12 }}>
+                <Text style={{ color: homeRadarMode === option.key ? theme.primary : theme.textSecondary, fontWeight: "600", fontSize: 12 }}>
                   {option.label}
                 </Text>
               </Pressable>
@@ -265,7 +265,7 @@ export default function HomeScreen({ navigation, onAccountDeleted }: HomeScreenP
             goals={activeGoals}
             size={250}
             referenceDate={selectedDate}
-            mode={radarMode}
+            mode={homeRadarMode}
             emptyTitle={goals.length > 0 ? "No active goals" : undefined}
             emptyHelperText={goals.length > 0 ? "Complete or add a goal to compare active progress" : undefined}
           />

--- a/components/OverviewScreen.tsx
+++ b/components/OverviewScreen.tsx
@@ -30,8 +30,9 @@ export default function OverviewScreen({ navigation, route }: OverviewProps) {
   const goal = useStore((s) => s.goals.find((g) => g.id === goalId)!);
   const selectedDate = useStore((s) => s.selectedDate);
   const frozenDays = useStore((s) => s.frozenDays);
+  const viewMode = useStore((s) => s.consistencyViewMode);
+  const setConsistencyViewMode = useStore((s) => s.setConsistencyViewMode);
   const { theme } = useTheme();
-  const [viewMode, setViewMode] = React.useState<"summary" | "tasks">("tasks");
 
   if (!goal) return <Text>Goal not found</Text>;
 
@@ -96,7 +97,7 @@ export default function OverviewScreen({ navigation, route }: OverviewProps) {
           ] as const).map((option) => (
             <Pressable
               key={option.key}
-              onPress={() => setViewMode(option.key)}
+              onPress={() => setConsistencyViewMode(option.key)}
               style={{
                 paddingHorizontal: 10,
                 paddingVertical: 6,

--- a/homeScreen.test.tsx
+++ b/homeScreen.test.tsx
@@ -1,0 +1,120 @@
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react-native';
+import HomeScreen from './components/HomeScreen';
+
+jest.mock('@expo/vector-icons', () => ({
+  Ionicons: 'Ionicons',
+}));
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  removeItem: jest.fn(),
+}));
+
+jest.mock('react-native-safe-area-context', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return {
+    SafeAreaView: ({ children }: { children: React.ReactNode }) => <View>{children}</View>,
+  };
+});
+
+jest.mock('react-native-draggable-flatlist', () => 'DraggableFlatList');
+
+jest.mock('./components/RadarChart', () => {
+  const React = require('react');
+  const { Text } = require('react-native');
+  return function MockRadarChart(props: { mode: string }) {
+    return <Text testID="radar-chart">mode:{props.mode}</Text>;
+  };
+});
+
+jest.mock('./components/DateContextCard', () => 'DateContextCard');
+jest.mock('./components/CalendarModal', () => 'CalendarModal');
+
+jest.mock('./utils/haptics', () => ({
+  haptics: {
+    tap: jest.fn().mockResolvedValue(undefined),
+    navigate: jest.fn().mockResolvedValue(undefined),
+    warning: jest.fn().mockResolvedValue(undefined),
+  },
+}));
+
+jest.mock('./lib/dateContext', () => ({
+  getNextTrackingDate: (date: Date) => date,
+  getPreviousTrackingDate: (date: Date) => date,
+}));
+
+jest.mock('./lib/auth', () => ({
+  deleteCurrentAccount: jest.fn(),
+}));
+
+jest.mock('./onboarding', () => ({
+  ONBOARDING_STORAGE_KEY: 'onboarding-key',
+}));
+
+jest.mock('./contexts/ThemeContext', () => ({
+  useTheme: () => ({
+    theme: {
+      background: '#000',
+      surface: '#111',
+      text: '#fff',
+      textSecondary: '#aaa',
+      border: '#333',
+      primary: '#0af',
+      warning: '#fa0',
+      success: '#0f0',
+    },
+    isDark: true,
+    toggleTheme: jest.fn(),
+  }),
+}));
+
+const setHomeRadarMode = jest.fn();
+
+const mockState = {
+  goals: [],
+  selectedDate: new Date('2026-05-06T12:00:00.000Z'),
+  account: null,
+  setSelectedDate: jest.fn(),
+  reorderGoals: jest.fn(),
+  deleteGoal: jest.fn(),
+  setGoals: jest.fn(),
+  setAccount: jest.fn(),
+  setCloudSyncEnabled: jest.fn(),
+  freezeDay: jest.fn(),
+  unfreezeDay: jest.fn(),
+  isDayFrozen: jest.fn(() => false),
+  getFreezeReason: jest.fn(() => undefined),
+  homeRadarMode: 'current' as const,
+  setHomeRadarMode,
+};
+
+jest.mock('./store', () => ({
+  useStore: (selector: (state: typeof mockState) => unknown) => selector(mockState),
+  debugAsyncStorage: jest.fn(),
+  getCurrentMode: () => 'PROD',
+  getGoalProgress: () => ({ completed: 0, total: 0, percent: 0, isComplete: false }),
+}));
+
+describe('HomeScreen', () => {
+  beforeEach(() => {
+    setHomeRadarMode.mockClear();
+    mockState.homeRadarMode = 'current';
+  });
+
+  it('uses and updates the persisted radar mode preference', () => {
+    const navigation = { setOptions: jest.fn(), navigate: jest.fn() } as never;
+    const { getByText, getByTestId, rerender } = render(
+      <HomeScreen navigation={navigation} route={{ key: 'Home-1', name: 'Home' } as never} />,
+    );
+
+    expect(getByTestId('radar-chart').props.children.join('')).toContain('mode:current');
+
+    fireEvent.press(getByText('All-time trend'));
+    expect(setHomeRadarMode).toHaveBeenCalledWith('trend');
+
+    mockState.homeRadarMode = 'trend';
+    rerender(<HomeScreen navigation={navigation} route={{ key: 'Home-1', name: 'Home' } as never} />);
+    expect(getByTestId('radar-chart').props.children.join('')).toContain('mode:trend');
+  });
+});

--- a/overviewScreen.test.tsx
+++ b/overviewScreen.test.tsx
@@ -45,9 +45,13 @@ jest.mock('./contexts/ThemeContext', () => ({
   }),
 }));
 
+const setConsistencyViewMode = jest.fn();
+
 const mockState = {
   selectedDate: new Date('2026-05-06T12:00:00.000Z'),
   frozenDays: [] as Array<{ date: string; reason: string; createdAt: number }>,
+  consistencyViewMode: 'tasks' as const,
+  setConsistencyViewMode,
   goals: [
     {
       id: 'goal-1',
@@ -90,8 +94,13 @@ jest.mock('./store', () => ({
 }));
 
 describe('OverviewScreen', () => {
+  beforeEach(() => {
+    setConsistencyViewMode.mockClear();
+    mockState.consistencyViewMode = 'tasks';
+  });
+
   it('lets users switch to a goal-level summary heatmap', () => {
-    const { getByText, getAllByTestId, queryByText } = render(
+    const { getByText, getAllByTestId, queryByText, rerender } = render(
       <OverviewScreen
         navigation={{} as never}
         route={{ key: 'Consistency-1', name: 'Consistency', params: { goalId: 'goal-1' } } as never}
@@ -103,6 +112,15 @@ describe('OverviewScreen', () => {
     expect(queryByText('Goal summary heatmap')).toBeNull();
 
     fireEvent.press(getByText('Summary'));
+
+    expect(setConsistencyViewMode).toHaveBeenCalledWith('summary');
+    mockState.consistencyViewMode = 'summary';
+    rerender(
+      <OverviewScreen
+        navigation={{} as never}
+        route={{ key: 'Consistency-1', name: 'Consistency', params: { goalId: 'goal-1' } } as never}
+      />,
+    );
 
     expect(getByText('Goal summary heatmap')).toBeTruthy();
     expect(getByText(/what percentage of this goal’s recurring tasks/i)).toBeTruthy();
@@ -134,5 +152,19 @@ describe('OverviewScreen', () => {
     expect(getByText('Stretch')).toBeTruthy();
     expect(queryByText('Buy shoes')).toBeNull();
     expect(queryByText('Book physio')).toBeNull();
+  });
+
+  it('respects the persisted summary view preference on first render', () => {
+    mockState.consistencyViewMode = 'summary';
+
+    const { getByText, queryByText } = render(
+      <OverviewScreen
+        navigation={{} as never}
+        route={{ key: 'Consistency-1', name: 'Consistency', params: { goalId: 'goal-1' } } as never}
+      />,
+    );
+
+    expect(getByText('Goal summary heatmap')).toBeTruthy();
+    expect(queryByText('Walk')).toBeNull();
   });
 });

--- a/store.ts
+++ b/store.ts
@@ -660,6 +660,8 @@ interface State {
     syncRevision: number;
     lastSyncedRevision: number;
     frozenDays: FreezeDay[];
+    homeRadarMode: "current" | "trend";
+    consistencyViewMode: "summary" | "tasks";
     setGoals: (goals: Goal[]) => void;
     setCloudSyncEnabled: (enabled: boolean) => void;
     markGoalsSynced: (revision: number) => void;
@@ -678,6 +680,8 @@ interface State {
     unfreezeDay: (date: Date) => void;
     isDayFrozen: (date: Date) => boolean;
     getFreezeReason: (date: Date) => string | undefined;
+    setHomeRadarMode: (mode: "current" | "trend") => void;
+    setConsistencyViewMode: (mode: "summary" | "tasks") => void;
     completionsByDate: () => Record<string, number>;
     deleteGoal: (goalId: string) => void;
     resetAppData: () => void;
@@ -716,6 +720,8 @@ export const useStore = create<State>()(
             syncRevision: 0,
             lastSyncedRevision: 0,
             frozenDays: [],
+            homeRadarMode: "current",
+            consistencyViewMode: "tasks",
 
             /**
              * This setter is the bridge between remote reads and the existing
@@ -965,6 +971,14 @@ export const useStore = create<State>()(
                 return get().frozenDays.find((fd) => fd.date === dateKey)?.reason;
             },
 
+            setHomeRadarMode: (mode) => {
+                set({ homeRadarMode: mode });
+            },
+
+            setConsistencyViewMode: (mode) => {
+                set({ consistencyViewMode: mode });
+            },
+
             completionsByDate: () => {
                 const map: Record<string, number> = {};
                 for (const g of get().goals) {
@@ -1033,6 +1047,11 @@ export const useStore = create<State>()(
                             : state.selectedDate;
                     } else if (state) {
                         state.selectedDate = normalizeDate(new Date());
+                    }
+
+                    if (state) {
+                        state.homeRadarMode = state.homeRadarMode === "trend" ? "trend" : "current";
+                        state.consistencyViewMode = state.consistencyViewMode === "summary" ? "summary" : "tasks";
                     }
                 };
             },


### PR DESCRIPTION
## Summary\n- persist the home consistency overview mode between sessions\n- persist the goal consistency page summary vs per-task selection between sessions\n- add regression tests covering both stored preferences\n\nCloses #130\n\n## Testing\n- npm test -- --runInBand\n