### PR TITLE
Add an explicit onboarding start choice

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -15,6 +15,7 @@ import OverviewScreen from "./components/OverviewScreen";
 import PrivacyScreen from "./components/PrivacyScreen";
 import InstructionsScreen from "./components/InstructionsScreen";
 import IntroductionWizard from "./components/IntroductionWizard";
+import OnboardingChoiceScreen from "./components/OnboardingChoiceScreen";
 import AuthScreen from "./components/AuthScreen";
 import ImportLocalDataScreen from "./components/ImportLocalDataScreen";
 import AccountDeletedScreen from "./components/AccountDeletedScreen";
@@ -40,12 +41,15 @@ function ThemedNavigation() {
   const goals = useStore((s) => s.goals);
   const setAccount = useStore((s) => s.setAccount);
   const setGoals = useStore((s) => s.setGoals);
+  const seedDemoData = useStore((s) => s.seedDemoData);
+  const resetAppData = useStore((s) => s.resetAppData);
   const cloudSyncEnabled = useStore((s) => s.cloudSyncEnabled);
   const setCloudSyncEnabled = useStore((s) => s.setCloudSyncEnabled);
   const syncRevision = useStore((s) => s.syncRevision);
   const lastSyncedRevision = useStore((s) => s.lastSyncedRevision);
   const markGoalsSynced = useStore((s) => s.markGoalsSynced);
   const [showIntroduction, setShowIntroduction] = React.useState(false);
+  const [showOnboardingChoice, setShowOnboardingChoice] = React.useState(false);
   const [hasCheckedIntroduction, setHasCheckedIntroduction] = React.useState(false);
   const [hasCheckedSession, setHasCheckedSession] = React.useState(false);
   const [session, setSession] = React.useState<Session | null>(null);
@@ -240,10 +244,25 @@ function ThemedNavigation() {
       });
   }, [cloudSyncEnabled, lastSyncedRevision, markGoalsSynced, session, syncRevision]);
 
-  const handleIntroductionDone = React.useCallback(async () => {
+  const completeOnboarding = React.useCallback(async () => {
     await AsyncStorage.setItem(ONBOARDING_STORAGE_KEY, "true");
-    setShowIntroduction(false);
+    setShowOnboardingChoice(false);
   }, []);
+
+  const handleIntroductionDone = React.useCallback(() => {
+    setShowIntroduction(false);
+    setShowOnboardingChoice(true);
+  }, []);
+
+  const handleExploreDemoGoals = React.useCallback(async () => {
+    seedDemoData();
+    await completeOnboarding();
+  }, [completeOnboarding, seedDemoData]);
+
+  const handleStartFresh = React.useCallback(async () => {
+    resetAppData();
+    await completeOnboarding();
+  }, [completeOnboarding, resetAppData]);
 
   const handleImportLocalData = React.useCallback(async () => {
     if (!session?.user) {
@@ -350,6 +369,18 @@ function ThemedNavigation() {
     return (
       <>
         <IntroductionWizard onDone={handleIntroductionDone} />
+        <StatusBar style={isDark ? "light" : "dark"} />
+      </>
+    );
+  }
+
+  if (showOnboardingChoice) {
+    return (
+      <>
+        <OnboardingChoiceScreen
+          onExploreDemo={handleExploreDemoGoals}
+          onStartFresh={handleStartFresh}
+        />
         <StatusBar style={isDark ? "light" : "dark"} />
       </>
     );

--- a/components/InstructionsScreen.tsx
+++ b/components/InstructionsScreen.tsx
@@ -71,12 +71,12 @@ export default function InstructionsScreen() {
           </Text>
         </InfoSection>
 
-        <InfoSection title="7. Start with your own goals">
+        <InfoSection title="7. Choose demo mode or start fresh">
           <Text style={{ color: theme.textSecondary, lineHeight: 22 }}>
-            After onboarding and account setup, OnTrack starts empty. Add your own goals and tasks to build a consistency history that reflects your real routine.
+            At the end of onboarding, you can explore sample goals first or start with your own empty setup right away.
           </Text>
           <Text style={{ color: theme.textSecondary, lineHeight: 22 }}>
-            If you ever want to clear your local history on this device and start over, open Settings and use Reset App Data.
+            Reset App Data is still available in Settings if you ever want to clear this device later, but it is no longer the main path for beginning real use.
           </Text>
         </InfoSection>
       </ScrollView>

--- a/components/IntroductionWizard.tsx
+++ b/components/IntroductionWizard.tsx
@@ -85,8 +85,8 @@ const slides: Slide[] = [
   },
   {
     key: "start",
-    title: "Start with a clean slate",
-    text: "After the walkthrough and account setup, the app opens empty so you can add your own goals right away instead of clearing example data first.",
+    title: "Choose how you want to begin",
+    text: "At the end of onboarding, you can explore demo goals first or start fresh with your own goals right away.",
     icon: "checkmark-circle-outline",
   },
 ];
@@ -175,7 +175,7 @@ export default function IntroductionWizard({ onDone }: IntroductionWizardProps) 
               paddingVertical: 10,
             }}
           >
-            <Text style={{ color: theme.background, fontWeight: "700" }}>Open OnTrack</Text>
+            <Text style={{ color: theme.background, fontWeight: "700" }}>Choose a starting point</Text>
           </Pressable>
         )}
         showSkipButton

--- a/components/OnboardingChoiceScreen.tsx
+++ b/components/OnboardingChoiceScreen.tsx
@@ -1,0 +1,77 @@
+import React from "react";
+import { Pressable, Text, View } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { Ionicons } from "@expo/vector-icons";
+import { useTheme } from "../contexts/ThemeContext";
+
+type OnboardingChoiceScreenProps = {
+  onExploreDemo: () => void;
+  onStartFresh: () => void;
+};
+
+export default function OnboardingChoiceScreen({ onExploreDemo, onStartFresh }: OnboardingChoiceScreenProps) {
+  const { theme } = useTheme();
+
+  return (
+    <SafeAreaView style={{ flex: 1, backgroundColor: theme.background }}>
+      <View style={{ flex: 1, padding: 24, justifyContent: "center", gap: 18 }}>
+        <View
+          style={{
+            width: 88,
+            height: 88,
+            borderRadius: 44,
+            alignItems: "center",
+            justifyContent: "center",
+            backgroundColor: theme.surface,
+            borderWidth: 1,
+            borderColor: theme.border,
+            alignSelf: "center",
+          }}
+        >
+          <Ionicons name="sparkles-outline" size={40} color={theme.primary} />
+        </View>
+
+        <View style={{ gap: 10 }}>
+          <Text style={{ color: theme.text, fontSize: 28, fontWeight: "800", textAlign: "center" }}>
+            How do you want to start?
+          </Text>
+          <Text style={{ color: theme.textSecondary, fontSize: 16, lineHeight: 24, textAlign: "center" }}>
+            You can explore OnTrack with sample goals first, or begin with a clean slate and add your own goals right away.
+          </Text>
+        </View>
+
+        <Pressable
+          onPress={onExploreDemo}
+          style={{
+            borderRadius: 18,
+            padding: 18,
+            backgroundColor: theme.surface,
+            borderWidth: 1,
+            borderColor: theme.border,
+            gap: 8,
+          }}
+        >
+          <Text style={{ color: theme.text, fontSize: 18, fontWeight: "700" }}>Explore demo goals</Text>
+          <Text style={{ color: theme.textSecondary, lineHeight: 22 }}>
+            Start with example goals and sample history so you can look around before creating your own routine.
+          </Text>
+        </Pressable>
+
+        <Pressable
+          onPress={onStartFresh}
+          style={{
+            borderRadius: 18,
+            padding: 18,
+            backgroundColor: theme.primary,
+            gap: 8,
+          }}
+        >
+          <Text style={{ color: theme.background, fontSize: 18, fontWeight: "700" }}>Start with my own goals</Text>
+          <Text style={{ color: theme.background, lineHeight: 22, opacity: 0.9 }}>
+            Clear any sample data and head into OnTrack ready to build your own setup from scratch.
+          </Text>
+        </Pressable>
+      </View>
+    </SafeAreaView>
+  );
+}

--- a/onboardingChoiceScreen.test.tsx
+++ b/onboardingChoiceScreen.test.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react-native';
+import OnboardingChoiceScreen from './components/OnboardingChoiceScreen';
+
+jest.mock('@expo/vector-icons', () => ({
+  Ionicons: 'Ionicons',
+}));
+
+jest.mock('react-native-safe-area-context', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return {
+    SafeAreaView: ({ children }: { children: React.ReactNode }) => <View>{children}</View>,
+  };
+});
+
+jest.mock('./contexts/ThemeContext', () => ({
+  useTheme: () => ({
+    theme: {
+      background: '#000',
+      surface: '#111',
+      text: '#fff',
+      textSecondary: '#aaa',
+      border: '#333',
+      primary: '#0af',
+    },
+  }),
+}));
+
+describe('OnboardingChoiceScreen', () => {
+  it('lets users choose between demo data and a clean start', () => {
+    const onExploreDemo = jest.fn();
+    const onStartFresh = jest.fn();
+    const { getByText } = render(
+      <OnboardingChoiceScreen onExploreDemo={onExploreDemo} onStartFresh={onStartFresh} />,
+    );
+
+    fireEvent.press(getByText('Explore demo goals'));
+    expect(onExploreDemo).toHaveBeenCalledTimes(1);
+
+    fireEvent.press(getByText('Start with my own goals'));
+    expect(onStartFresh).toHaveBeenCalledTimes(1);
+  });
+});

--- a/store.ts
+++ b/store.ts
@@ -660,6 +660,7 @@ interface State {
     syncRevision: number;
     lastSyncedRevision: number;
     frozenDays: FreezeDay[];
+    seedDemoData: () => void;
     setGoals: (goals: Goal[]) => void;
     setCloudSyncEnabled: (enabled: boolean) => void;
     markGoalsSynced: (revision: number) => void;
@@ -716,6 +717,14 @@ export const useStore = create<State>()(
             syncRevision: 0,
             lastSyncedRevision: 0,
             frozenDays: [],
+
+            seedDemoData: () =>
+                set((s) => ({
+                    goals: getSampleGoals(),
+                    selectedDate: normalizeDate(new Date()),
+                    frozenDays: [],
+                    syncRevision: s.syncRevision + 1,
+                })),
 
             /**
              * This setter is the bridge between remote reads and the existing
@@ -992,6 +1001,7 @@ export const useStore = create<State>()(
                 set((s) => ({
                     goals: getInitialGoals(),
                     selectedDate: normalizeDate(new Date()),
+                    frozenDays: [],
                     account: s.account,
                     syncRevision: s.syncRevision + 1,
                 }));

--- a/tests/store.test.ts
+++ b/tests/store.test.ts
@@ -206,6 +206,7 @@ describe('account setup state', () => {
       goals: [],
       selectedDate: new Date('2026-05-01T12:00:00.000Z'),
       account: null,
+      frozenDays: [],
     });
   });
 
@@ -227,16 +228,31 @@ describe('account setup state', () => {
     useStore.setState({
       goals: getSampleGoals(),
       selectedDate: new Date('2026-04-20T12:00:00.000Z'),
+      frozenDays: [{ date: '2026-04-19', reason: 'Travel', createdAt: Date.now() }],
     });
 
     useStore.getState().resetAppData();
 
     expect(useStore.getState().goals).toEqual([]);
+    expect(useStore.getState().frozenDays).toEqual([]);
     expect(useStore.getState().account).toMatchObject({
       displayName: 'Adam Lin',
       username: 'adam',
       email: 'adam@example.com',
     });
+  });
+
+  it('seeds demo goals for the onboarding explore path', () => {
+    useStore.setState({
+      goals: [],
+      frozenDays: [{ date: '2026-04-19', reason: 'Travel', createdAt: Date.now() }],
+      selectedDate: new Date('2026-04-20T12:00:00.000Z'),
+    });
+
+    useStore.getState().seedDemoData();
+
+    expect(useStore.getState().goals.length).toBeGreaterThan(0);
+    expect(useStore.getState().frozenDays).toEqual([]);
   });
 });
 


### PR DESCRIPTION
## Summary\n- add an onboarding handoff screen so users can choose demo goals or start fresh\n- seed demo goals for the explore path and reuse reset for the clean-slate path\n- update onboarding copy and add regression coverage for the new behavior\n\nCloses #3\n\n## Testing\n- npm test -- --runInBand\n