### PR TITLE
Update README clone instructions and project map

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ OnTrack is a habit tracking mobile app built with React Native and Expo. It focu
 ### Install
 
 ```bash
-git clone https://github.com/KyleNewbigging/OnTrack.git
+git clone https://github.com/OnTrackOrg/on-track-mobile.git OnTrack
 cd OnTrack
 npm install
 ```
@@ -77,12 +77,16 @@ npm run lint
 
 ```text
 OnTrack/
+├── assets/       # App icons and bundled images
 ├── components/   # UI screens and reusable visual components
 ├── contexts/     # React context providers
-├── docs/         # Supporting project documentation
-├── tests/        # Jest unit tests
-├── scripts/      # Utility scripts
+├── docs/         # Product and technical notes
+├── lib/          # Shared app logic and integrations
+├── supabase/     # SQL migrations and edge function sources
+├── tests/        # Jest test files
+├── utils/        # Small reusable helpers
 ├── App.tsx       # App entry component
+├── navigation.ts # Navigation types and route definitions
 ├── store.ts      # Zustand state and persistence
 ├── types.ts      # Shared TypeScript types
 └── README.md
@@ -91,9 +95,9 @@ OnTrack/
 ## Documentation map
 
 - `README.md`: quick start and repo overview
-- `AGENTS.md`: how Hugo should operate in this repo
 - `TODO.md`: backlog notes that are not yet formalized as issues
-- `docs/`: focused supporting docs
+- `docs/`: focused product and engineering docs
+- `supabase/`: backend-related migrations and functions used by the app
 
 ## Notes
 


### PR DESCRIPTION
This is Echo, Kyle's OpenClaw agent, submitting this PR.

## Summary of changes
- updated the README clone command to use the canonical `OnTrackOrg/on-track-mobile` repository
- kept the local folder name as `OnTrack` so the documented `cd OnTrack` step still works
- refreshed the project structure section so it only lists directories and files that exist in the current checkout
- removed the stale `AGENTS.md` doc reference and replaced it with current repo documentation entries

## Edge cases or non-goals
- this PR only fixes README drift, it does not change app behavior or project structure
- I did not rewrite the full README beyond the sections needed to resolve the documented mismatches

## Validation run
- `node - <<'NODE' ... NODE` to verify every README path referenced in the updated structure/docs map exists in the repo
- `npx prettier --check README.md`

## Checkout command
- `git fetch origin && git checkout echo/issue-138-update-readme-clone-map`

Closes #138
