### PR TITLE
Fix Home settings copy after cloud sync launch

### DIFF
--- a/components/HomeScreen.tsx
+++ b/components/HomeScreen.tsx
@@ -46,6 +46,10 @@ import {
   saveReminderSettings,
   syncDailyReminder,
 } from "../lib/reminders";
+import {
+  getAccountSettingsDescription,
+  getPrivacySettingsDescription,
+} from "./homeSettingsCopy";
 
 type HomeProps = NativeStackScreenProps<RootStackParamList, "Home">;
 
@@ -60,6 +64,7 @@ export default function HomeScreen({
   const goals = useStore((s) => s.goals);
   const selectedDate = useStore((s) => s.selectedDate);
   const account = useStore((s) => s.account);
+  const cloudSyncEnabled = useStore((s) => s.cloudSyncEnabled);
   const setSelectedDate = useStore((s) => s.setSelectedDate);
   const reorderGoals = useStore((s) => s.reorderGoals);
   const deleteGoal = useStore((s) => s.deleteGoal);
@@ -807,8 +812,7 @@ export default function HomeScreen({
                   {account.displayName} @{account.username}
                 </Text>
                 <Text style={{ color: theme.textSecondary, marginTop: 4 }}>
-                  This profile will be used for future sync and communication
-                  features.
+                  {getAccountSettingsDescription(cloudSyncEnabled)}
                 </Text>
               </View>
             ) : null}
@@ -860,7 +864,7 @@ export default function HomeScreen({
                 Privacy & Data
               </Text>
               <Text style={{ color: theme.textSecondary, marginTop: 4 }}>
-                Goals and completion history stay on this device.
+                {getPrivacySettingsDescription(cloudSyncEnabled)}
               </Text>
             </Pressable>
 

--- a/components/homeSettingsCopy.ts
+++ b/components/homeSettingsCopy.ts
@@ -1,0 +1,13 @@
+export const getAccountSettingsDescription = (
+  cloudSyncEnabled: boolean,
+): string =>
+  cloudSyncEnabled
+    ? "Signed in to sync and back up your goals with this account."
+    : "Signed in. Any existing goals on this device stay local until you choose to import them for cloud backup.";
+
+export const getPrivacySettingsDescription = (
+  cloudSyncEnabled: boolean,
+): string =>
+  cloudSyncEnabled
+    ? "Goals and completion history stay on this device and sync to your account for backup."
+    : "Goals and completion history stay on this device until you choose to import them for account sync and backup.";

--- a/homeSettingsCopy.test.ts
+++ b/homeSettingsCopy.test.ts
@@ -1,0 +1,24 @@
+import {
+  getAccountSettingsDescription,
+  getPrivacySettingsDescription,
+} from "./components/homeSettingsCopy";
+
+describe("home settings copy", () => {
+  it("describes active cloud sync without implying it is still future work", () => {
+    expect(getAccountSettingsDescription(true)).toBe(
+      "Signed in to sync and back up your goals with this account.",
+    );
+    expect(getPrivacySettingsDescription(true)).toBe(
+      "Goals and completion history stay on this device and sync to your account for backup.",
+    );
+  });
+
+  it("describes pending local-data import when cloud sync is not on yet", () => {
+    expect(getAccountSettingsDescription(false)).toBe(
+      "Signed in. Any existing goals on this device stay local until you choose to import them for cloud backup.",
+    );
+    expect(getPrivacySettingsDescription(false)).toBe(
+      "Goals and completion history stay on this device until you choose to import them for account sync and backup.",
+    );
+  });
+});


### PR DESCRIPTION
This is Echo, Kyle's OpenClaw agent, submitting this PR.

## Summary of changes
- updates the Home settings Account card so it reflects shipped sync/backup behavior instead of describing sync as a future feature
- updates the Privacy & Data card copy to describe both active cloud sync and the pending local-import state
- extracts the settings copy into a small helper and adds focused coverage for both sync states

## Edge cases or non-goals
- keeps the change scoped to Home settings copy only; the deeper Privacy screen copy was already accurate
- preserves the explicit local-data import flow for signed-in users who still have device-only data

## Validation run
- `npm test -- --runInBand homeSettingsCopy.test.ts`
- `npm run typecheck`
- `npx prettier --check components/HomeScreen.tsx components/homeSettingsCopy.ts homeSettingsCopy.test.ts`

## Checkout command
- `git fetch origin && git checkout echo/issue-140-home-settings-sync-copy`

Closes #140
