### PR TITLE
Add app-level day reflections

### DIFF
--- a/components/CalendarModal.tsx
+++ b/components/CalendarModal.tsx
@@ -21,6 +21,7 @@ import IconButton from "./IconButton";
 interface CalendarModalProps {
   visible: boolean;
   selectedDate: Date;
+  reflectionDates?: string[];
   onClose: () => void;
   onSelectDate: (date: Date) => void;
 }
@@ -30,11 +31,16 @@ const WEEKDAY_LABELS = ["S", "M", "T", "W", "T", "F", "S"];
 export default function CalendarModal({
   visible,
   selectedDate,
+  reflectionDates = [],
   onClose,
   onSelectDate,
 }: CalendarModalProps) {
   const { theme } = useTheme();
   const today = startOfDay(new Date());
+  const reflectionDateSet = React.useMemo(
+    () => new Set(reflectionDates),
+    [reflectionDates],
+  );
   const [displayMonth, setDisplayMonth] = React.useState(
     startOfMonth(selectedDate),
   );
@@ -192,6 +198,9 @@ export default function CalendarModal({
               const isSelected = isSameDay(day, selectedDate);
               const isCurrentMonth = isSameMonth(day, displayMonth);
               const isCurrentDay = isSameDay(day, today);
+              const hasReflection = reflectionDateSet.has(
+                format(day, "yyyy-MM-dd"),
+              );
 
               return (
                 <View
@@ -231,6 +240,20 @@ export default function CalendarModal({
                     >
                       {format(day, "d")}
                     </Text>
+                    {hasReflection ? (
+                      <View
+                        style={{
+                          position: "absolute",
+                          bottom: 4,
+                          width: 5,
+                          height: 5,
+                          borderRadius: 999,
+                          backgroundColor: isSelected
+                            ? "#ffffff"
+                            : theme.primary,
+                        }}
+                      />
+                    ) : null}
                   </Pressable>
                 </View>
               );

--- a/components/DateContextCard.tsx
+++ b/components/DateContextCard.tsx
@@ -4,6 +4,7 @@ import { Ionicons } from "@expo/vector-icons";
 import { format, isToday, isFuture } from "date-fns";
 import { useTheme } from "../contexts/ThemeContext";
 import { haptics } from "../utils/haptics";
+import { DayReflectionRating } from "../types";
 import IconButton from "./IconButton";
 import FreezeDayModal from "./FreezeDayModal";
 
@@ -11,24 +12,39 @@ interface DateContextCardProps {
   selectedDate: Date;
   isFrozen: boolean;
   freezeReason?: string;
+  dayReflection?: DayReflectionRating;
   hasCompletions: boolean;
   onPress: () => void;
   onPreviousDay: () => void;
   onNextDay: () => void;
   onFreezeDay: (reason: string) => void;
   onUnfreezeDay: () => void;
+  onSetDayReflection: (rating: DayReflectionRating) => void;
+  onClearDayReflection: () => void;
 }
+
+const REFLECTION_META: Record<
+  DayReflectionRating,
+  { emoji: string; label: string; description: string }
+> = {
+  good: { emoji: "🙂", label: "Good day", description: "Overall, this felt like a good day" },
+  mixed: { emoji: "😐", label: "Mixed day", description: "This day felt mixed or uneven" },
+  rough: { emoji: "😞", label: "Rough day", description: "This was a rough day overall" },
+};
 
 export default function DateContextCard({
   selectedDate,
   isFrozen,
   freezeReason,
+  dayReflection,
   hasCompletions,
   onPress,
   onPreviousDay,
   onNextDay,
   onFreezeDay,
   onUnfreezeDay,
+  onSetDayReflection,
+  onClearDayReflection,
 }: DateContextCardProps) {
   const { theme, isDark } = useTheme();
   const viewingToday = isToday(selectedDate);
@@ -75,6 +91,46 @@ export default function DateContextCard({
       ],
     );
   };
+
+  const handleReflectionPress = () => {
+    void haptics.tap();
+    const reflectionButtons: Array<{
+      text: string;
+      onPress?: () => void;
+      style?: "cancel" | "default" | "destructive";
+    }> = (
+      Object.entries(REFLECTION_META) as Array<
+        [DayReflectionRating, (typeof REFLECTION_META)[DayReflectionRating]]
+      >
+    ).map(([rating, meta]) => ({
+      text: `${meta.emoji} ${meta.label}`,
+      onPress: () => {
+        void haptics.tap();
+        onSetDayReflection(rating);
+      },
+    }));
+
+    if (dayReflection) {
+      reflectionButtons.push({
+        text: "Clear reflection",
+        style: "destructive",
+        onPress: () => {
+          void haptics.warning();
+          onClearDayReflection();
+        },
+      });
+    }
+
+    reflectionButtons.push({ text: "Cancel", style: "cancel" });
+
+    Alert.alert(
+      "How did this day feel?",
+      "Save a quick day-level reflection without changing your goals or streaks.",
+      reflectionButtons,
+    );
+  };
+
+  const reflectionMeta = dayReflection ? REFLECTION_META[dayReflection] : null;
 
   return (
     <>
@@ -153,6 +209,13 @@ export default function DateContextCard({
                 >
                   {freezeReason}
                 </Text>
+              ) : reflectionMeta ? (
+                <Text
+                  style={{ color: theme.textSecondary, marginTop: 2, fontSize: 13 }}
+                  numberOfLines={2}
+                >
+                  {reflectionMeta.emoji} {reflectionMeta.label}
+                </Text>
               ) : (
                 <Text style={{ color: theme.textSecondary, marginTop: 2 }}>
                   {viewingToday
@@ -208,6 +271,32 @@ export default function DateContextCard({
             <Ionicons name="chevron-forward" size={16} color={theme.text} />
           </Pressable>
         </View>
+
+        {!isFutureDate ? (
+          <Pressable
+            onPress={handleReflectionPress}
+            style={{
+              flexDirection: "row",
+              alignItems: "center",
+              justifyContent: "center",
+              gap: 6,
+              backgroundColor: theme.background,
+              borderWidth: 1,
+              borderColor: theme.border,
+              borderRadius: 10,
+              paddingVertical: 10,
+            }}
+          >
+            <Text style={{ fontSize: 16 }}>
+              {reflectionMeta ? reflectionMeta.emoji : "💭"}
+            </Text>
+            <Text style={{ color: theme.textSecondary, fontWeight: "600" }}>
+              {reflectionMeta
+                ? `Reflection: ${reflectionMeta.label}`
+                : "Add Day Reflection"}
+            </Text>
+          </Pressable>
+        ) : null}
 
         {/* Freeze / Unfreeze row - only for today or past dates without completions */}
         {!isFutureDate &&

--- a/components/HomeScreen.tsx
+++ b/components/HomeScreen.tsx
@@ -70,6 +70,10 @@ export default function HomeScreen({
   const unfreezeDay = useStore((s) => s.unfreezeDay);
   const isDayFrozen = useStore((s) => s.isDayFrozen);
   const getFreezeReason = useStore((s) => s.getFreezeReason);
+  const getDayReflection = useStore((s) => s.getDayReflection);
+  const setDayReflection = useStore((s) => s.setDayReflection);
+  const clearDayReflection = useStore((s) => s.clearDayReflection);
+  const dayReflections = useStore((s) => s.dayReflections);
   const currentMode = getCurrentMode();
   const { theme, isDark, toggleTheme } = useTheme();
   const [settingsVisible, setSettingsVisible] = useState(false);
@@ -338,6 +342,7 @@ export default function HomeScreen({
             selectedDate={selectedDate}
             isFrozen={isDayFrozen(selectedDate)}
             freezeReason={getFreezeReason(selectedDate)}
+            dayReflection={getDayReflection(selectedDate)?.rating}
             hasCompletions={hasCompletionsOnDate}
             onPress={() => {
               void haptics.tap();
@@ -361,6 +366,12 @@ export default function HomeScreen({
             }}
             onUnfreezeDay={() => {
               unfreezeDay(selectedDate);
+            }}
+            onSetDayReflection={(rating) => {
+              setDayReflection(selectedDate, rating);
+            }}
+            onClearDayReflection={() => {
+              clearDayReflection(selectedDate);
             }}
           />
 
@@ -974,6 +985,7 @@ export default function HomeScreen({
       <CalendarModal
         visible={calendarVisible}
         selectedDate={selectedDate}
+        reflectionDates={dayReflections.map((reflection) => reflection.date)}
         onClose={() => setCalendarVisible(false)}
         onSelectDate={(date) => setSelectedDate(date)}
       />

--- a/components/TrackingDateControls.tsx
+++ b/components/TrackingDateControls.tsx
@@ -22,6 +22,10 @@ export default function TrackingDateControls({
   const unfreezeDay = useStore((s) => s.unfreezeDay);
   const isDayFrozen = useStore((s) => s.isDayFrozen);
   const getFreezeReason = useStore((s) => s.getFreezeReason);
+  const getDayReflection = useStore((s) => s.getDayReflection);
+  const setDayReflection = useStore((s) => s.setDayReflection);
+  const clearDayReflection = useStore((s) => s.clearDayReflection);
+  const dayReflections = useStore((s) => s.dayReflections);
   const [calendarVisible, setCalendarVisible] = React.useState(false);
 
   return (
@@ -30,6 +34,7 @@ export default function TrackingDateControls({
         selectedDate={selectedDate}
         isFrozen={isDayFrozen(selectedDate)}
         freezeReason={getFreezeReason(selectedDate)}
+        dayReflection={getDayReflection(selectedDate)?.rating}
         hasCompletions={hasCompletions}
         onPress={() => {
           void haptics.tap();
@@ -54,11 +59,18 @@ export default function TrackingDateControls({
         onUnfreezeDay={() => {
           unfreezeDay(selectedDate);
         }}
+        onSetDayReflection={(rating) => {
+          setDayReflection(selectedDate, rating);
+        }}
+        onClearDayReflection={() => {
+          clearDayReflection(selectedDate);
+        }}
       />
 
       <CalendarModal
         visible={calendarVisible}
         selectedDate={selectedDate}
+        reflectionDates={dayReflections.map((reflection) => reflection.date)}
         onClose={() => setCalendarVisible(false)}
         onSelectDate={(date) => setSelectedDate(date)}
       />

--- a/overviewScreen.test.tsx
+++ b/overviewScreen.test.tsx
@@ -61,11 +61,19 @@ jest.mock("./lib/persistence", () => ({
 const mockState = {
   selectedDate: new Date("2026-05-06T12:00:00.000Z"),
   frozenDays: [] as Array<{ date: string; reason: string; createdAt: number }>,
+  dayReflections: [] as Array<{
+    date: string;
+    rating: "good" | "mixed" | "rough";
+    updatedAt: number;
+  }>,
   setSelectedDate: jest.fn(),
   freezeDay: jest.fn(),
   unfreezeDay: jest.fn(),
   isDayFrozen: jest.fn(() => false),
   getFreezeReason: jest.fn(() => undefined),
+  setDayReflection: jest.fn(),
+  clearDayReflection: jest.fn(),
+  getDayReflection: jest.fn(() => undefined),
   goals: [
     {
       id: "goal-1",

--- a/store.ts
+++ b/store.ts
@@ -8,6 +8,8 @@ import {
   Task,
   UserAccount,
   FreezeDay,
+  DayReflection,
+  DayReflectionRating,
 } from "./types";
 import {
   format,
@@ -875,6 +877,7 @@ interface State {
   syncRevision: number;
   lastSyncedRevision: number;
   frozenDays: FreezeDay[];
+  dayReflections: DayReflection[];
   setGoals: (goals: Goal[]) => void;
   setCloudSyncEnabled: (enabled: boolean) => void;
   markGoalsSynced: (revision: number) => void;
@@ -909,6 +912,10 @@ interface State {
   unfreezeDay: (date: Date) => void;
   isDayFrozen: (date: Date) => boolean;
   getFreezeReason: (date: Date) => string | undefined;
+  setDayReflection: (date: Date, rating: DayReflectionRating) => void;
+  clearDayReflection: (date: Date) => void;
+  getDayReflection: (date: Date) => DayReflection | undefined;
+  hasDayReflection: (date: Date) => boolean;
   completionsByDate: () => Record<string, number>;
   deleteGoal: (goalId: string) => void;
   resetAppData: () => void;
@@ -973,6 +980,7 @@ export const useStore = create<State>()(
       syncRevision: 0,
       lastSyncedRevision: 0,
       frozenDays: [],
+      dayReflections: [],
 
       /**
        * This setter is the bridge between remote reads and the existing
@@ -1234,6 +1242,41 @@ export const useStore = create<State>()(
         return get().frozenDays.find((fd) => fd.date === dateKey)?.reason;
       },
 
+      setDayReflection: (date, rating) => {
+        const dateKey = dateToKey(date);
+        set((s) => ({
+          dayReflections: [
+            ...s.dayReflections.filter((reflection) => reflection.date !== dateKey),
+            { date: dateKey, rating, updatedAt: Date.now() },
+          ],
+          syncRevision: s.syncRevision + 1,
+        }));
+      },
+
+      clearDayReflection: (date) => {
+        const dateKey = dateToKey(date);
+        set((s) => ({
+          dayReflections: s.dayReflections.filter(
+            (reflection) => reflection.date !== dateKey,
+          ),
+          syncRevision: s.syncRevision + 1,
+        }));
+      },
+
+      getDayReflection: (date) => {
+        const dateKey = dateToKey(date);
+        return get().dayReflections.find(
+          (reflection) => reflection.date === dateKey,
+        );
+      },
+
+      hasDayReflection: (date) => {
+        const dateKey = dateToKey(date);
+        return get().dayReflections.some(
+          (reflection) => reflection.date === dateKey,
+        );
+      },
+
       completionsByDate: () => {
         const map: Record<string, number> = {};
         for (const g of get().goals) {
@@ -1262,6 +1305,8 @@ export const useStore = create<State>()(
           goals: getInitialGoals(),
           selectedDate: normalizeDate(new Date()),
           account: s.account,
+          frozenDays: [],
+          dayReflections: [],
           syncRevision: s.syncRevision + 1,
         }));
       },

--- a/tests/store.test.ts
+++ b/tests/store.test.ts
@@ -6,7 +6,7 @@ import {
   isOnceTaskCompletedOnDate,
   useStore,
 } from "../store";
-import { FreezeDay, Goal, Task } from "../types";
+import { DayReflection, FreezeDay, Goal, Task } from "../types";
 import { format, startOfWeek } from "date-fns";
 
 describe("getCustomFrequencyProgress", () => {
@@ -524,6 +524,71 @@ describe("freeze day store actions", () => {
     const frozen = useStore.getState().frozenDays;
     expect(frozen).toHaveLength(1);
     expect(frozen[0].reason).toBe("Updated reason");
+  });
+});
+
+describe("day reflection store actions", () => {
+  const originalState = useStore.getState();
+
+  afterEach(() => {
+    useStore.setState(originalState, true);
+  });
+
+  it("setDayReflection persists a day-level reflection for the given date", () => {
+    const date = new Date("2026-05-10T12:00:00.000Z");
+
+    useStore.getState().setDayReflection(date, "good");
+
+    const reflections = useStore.getState().dayReflections;
+    expect(reflections).toHaveLength(1);
+    expect(reflections[0].date).toBe("2026-05-10");
+    expect(reflections[0].rating).toBe("good");
+  });
+
+  it("setDayReflection replaces an existing reflection for the same date", () => {
+    const date = new Date("2026-05-10T12:00:00.000Z");
+
+    useStore.getState().setDayReflection(date, "mixed");
+    useStore.getState().setDayReflection(date, "rough");
+
+    const reflections = useStore.getState().dayReflections;
+    expect(reflections).toHaveLength(1);
+    expect(reflections[0].rating).toBe("rough");
+  });
+
+  it("getDayReflection and hasDayReflection are scoped by normalized date", () => {
+    const date = new Date("2026-05-10T18:30:00.000Z");
+    const sameDayLater = new Date("2026-05-10T23:59:59.000Z");
+    const nextDay = new Date("2026-05-11T12:00:00.000Z");
+
+    useStore.getState().setDayReflection(date, "mixed");
+
+    expect(useStore.getState().hasDayReflection(sameDayLater)).toBe(true);
+    expect(useStore.getState().getDayReflection(sameDayLater)?.rating).toBe(
+      "mixed",
+    );
+    expect(useStore.getState().hasDayReflection(nextDay)).toBe(false);
+    expect(useStore.getState().getDayReflection(nextDay)).toBeUndefined();
+  });
+
+  it("clearDayReflection removes only the selected date's reflection", () => {
+    const firstDate = new Date("2026-05-10T12:00:00.000Z");
+    const secondDate = new Date("2026-05-11T12:00:00.000Z");
+
+    useStore.setState({
+      ...originalState,
+      dayReflections: [
+        { date: "2026-05-10", rating: "good", updatedAt: 1 },
+        { date: "2026-05-11", rating: "rough", updatedAt: 2 },
+      ] as DayReflection[],
+    });
+
+    useStore.getState().clearDayReflection(firstDate);
+
+    expect(useStore.getState().dayReflections).toEqual([
+      { date: "2026-05-11", rating: "rough", updatedAt: 2 },
+    ]);
+    expect(useStore.getState().hasDayReflection(secondDate)).toBe(true);
   });
 });
 

--- a/types.ts
+++ b/types.ts
@@ -6,6 +6,14 @@ export interface FreezeDay {
   createdAt: number; // Date.now() at freeze time
 }
 
+export type DayReflectionRating = "good" | "mixed" | "rough";
+
+export interface DayReflection {
+  date: string; // "yyyy-MM-dd" canonical day key
+  rating: DayReflectionRating;
+  updatedAt: number; // Date.now() at last update
+}
+
 export interface CustomFrequency {
   type: "weekly" | "monthly";
   target: number; // e.g., 3 times per week, 5 times per month


### PR DESCRIPTION
## Summary\n- add a persisted app-level day reflection model with set, clear, and lookup helpers\n- extend the shared date context card so users can add, change, or clear a reflection for the selected day\n- show subtle reflection markers in the calendar and cover the store behavior with tests\n\n## Testing\n- npm test -- --runInBand tests/store.test.ts overviewScreen.test.tsx\n- npm test -- --runInBand\n\nCloses #142